### PR TITLE
Add render count

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -120,6 +120,17 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "Belco90",
+      "name": "Mario Beltrán",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/2677072?v=4",
+      "profile": "https://mario.dev",
+      "contributions": [
+        "code",
+        "doc",
+        "test"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 [![downloads](https://img.shields.io/npm/dm/@testing-library/react-hooks.svg?style=flat-square)](http://www.npmtrends.com/@testing-library/react-hooks)
 [![MIT License](https://img.shields.io/npm/l/@testing-library/react-hooks.svg?style=flat-square)](https://github.com/testing-library/react-hooks-testing-library/blob/master/LICENSE.md)
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-11-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-12-orange.svg?style=flat-square)](#contributors-)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
 [![Code of Conduct](https://img.shields.io/badge/code%20of-conduct-ff69b4.svg?style=flat-square)](https://github.com/testing-library/react-hooks-testing-library/blob/master/CODE_OF_CONDUCT.md)
 [![Netlify Status](https://api.netlify.com/api/v1/badges/9a8f27a5-df38-4910-a248-4908b1ba29a7/deploy-status)](https://app.netlify.com/sites/react-hooks-testing-library/deploys)
@@ -142,7 +142,8 @@ See the [API documentation](https://react-hooks-testing-library.com/reference/ap
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-<!-- prettier-ignore -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
 <table>
   <tr>
     <td align="center"><a href="https://github.com/mpeyper"><img src="https://avatars0.githubusercontent.com/u/23029903?v=4" width="100px;" alt="Michael Peyper"/><br /><sub><b>Michael Peyper</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=mpeyper" title="Code">💻</a> <a href="#design-mpeyper" title="Design">🎨</a> <a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=mpeyper" title="Documentation">📖</a> <a href="#ideas-mpeyper" title="Ideas, Planning, & Feedback">🤔</a> <a href="#infra-mpeyper" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="#platform-mpeyper" title="Packaging/porting to new platform">📦</a> <a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=mpeyper" title="Tests">⚠️</a> <a href="#tool-mpeyper" title="Tools">🔧</a></td>
@@ -158,8 +159,12 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/mtinner"><img src="https://avatars0.githubusercontent.com/u/5487448?v=4" width="100px;" alt="Marcel Tinner"/><br /><sub><b>Marcel Tinner</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=mtinner" title="Documentation">📖</a></td>
     <td align="center"><a href="https://github.com/FredyC"><img src="https://avatars0.githubusercontent.com/u/1096340?v=4" width="100px;" alt="Daniel K."/><br /><sub><b>Daniel K.</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/issues?q=author%3AFredyC" title="Bug reports">🐛</a> <a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=FredyC" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/VinceMalone"><img src="https://avatars0.githubusercontent.com/u/2516349?v=4" width="100px;" alt="Vince Malone"/><br /><sub><b>Vince Malone</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=VinceMalone" title="Code">💻</a></td>
+    <td align="center"><a href="https://mario.dev"><img src="https://avatars1.githubusercontent.com/u/2677072?v=4" width="100px;" alt="Mario Beltrán"/><br /><sub><b>Mario Beltrán</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=Belco90" title="Code">💻</a> <a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=Belco90" title="Documentation">📖</a> <a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=Belco90" title="Tests">⚠️</a></td>
   </tr>
 </table>
+
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -62,12 +62,14 @@ The `renderHook` method returns an object that has a following properties:
 ```js
 {
   current: any,
-  error: Error
+  error: Error,
+  renderCount: number
 }
 ```
 
 The `current` value or the `result` will reflect whatever is returned from the `callback` passed to
-`renderHook`. Any thrown values will be reflected in the `error` value of the `result`.
+`renderHook`. Any thrown values will be reflected in the `error` value of the `result`. Within
+`renderCount` it's possible to know how many times the component was rendered.
 
 ### `waitForNextUpdate`
 

--- a/docs/usage/basic-hooks.md
+++ b/docs/usage/basic-hooks.md
@@ -221,3 +221,25 @@ test("should clean up side effect", () => {
 ```
 
 This is a fairly obscure case, so pick the method that fits best for you and your test.
+
+## Knowing how many times component was rendered
+
+It's also possible to know how many times the component containing the tested hook was rendered
+under `renderCount` property within result.
+
+```js
+import { renderHook, act } from '@testing-library/react-hooks'
+import { useState } from 'react'
+
+test('should rerender component on each update', () => {
+  const { result } = renderHook(() => useState('foo'))
+  const [, setState] = result.current
+  expect(result.renderCount).toBe(1)
+
+  act(() => {
+    setState('bar')
+  })
+
+  expect(result.renderCount).toBe(2)
+})
+```

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ function Fallback() {
 function resultContainer() {
   let value = null
   let error = null
+  let renderCount = 0
   const resolvers = []
 
   const result = {
@@ -32,10 +33,14 @@ function resultContainer() {
     },
     get error() {
       return error
+    },
+    get renderCount() {
+      return renderCount
     }
   }
 
   const updateResult = (val, err) => {
+    renderCount++
     value = val
     error = err
     resolvers.splice(0, resolvers.length).forEach((resolve) => resolve())

--- a/test/updateHook.test.js
+++ b/test/updateHook.test.js
@@ -1,0 +1,34 @@
+import { useState } from 'react'
+import { renderHook, act } from 'src'
+
+describe('update hook tests', () => {
+  function useUpdate() {
+    const [, setState] = useState(0)
+    return () => setState((count) => count + 1)
+  }
+
+  test('should increase render count every time hook update function is called', () => {
+    const { result } = renderHook(() => useUpdate())
+    const update = result.current
+
+    expect(result.renderCount).toBe(1)
+
+    act(() => update())
+    expect(result.renderCount).toBe(2)
+
+    act(() => update())
+    expect(result.renderCount).toBe(3)
+  })
+
+  test('should increase render count every time rerender function is called', () => {
+    const { result, rerender } = renderHook(() => useUpdate())
+
+    expect(result.renderCount).toBe(1)
+
+    rerender()
+    expect(result.renderCount).toBe(2)
+
+    rerender()
+    expect(result.renderCount).toBe(3)
+  })
+})

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -9,6 +9,7 @@ export interface RenderHookOptions<P> {
 export interface HookResult<R> {
   readonly current: R
   readonly error: Error
+  readonly renderCount: number
 }
 
 export interface RenderHookResult<P, R> {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->


**What**:
Implementing feature suggested to get how many times the component has been rendered https://github.com/testing-library/react-hooks-testing-library/issues/135
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**Why**:
At the moment there is no way of knowing how many times a component has been rendered due to a hook update, and it's an interesting value for checking performance, memoized behaviors or forced updates.
<!-- Why are these changes necessary? -->

**How**:
A count init to 0 within `resultContainer` that is increased every time `updateResult` is called, no matter if there is an error executing the hook as another render has been triggered so the counter must be increased to get corresponding count.
<!-- How were these changes implemented? -->

**Checklist**:

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove any items that are relevant to your changes
-->

- [x] Documentation updated
- [x] Tests
- [x] Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
