### PR TITLE
Global cleanup

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -9,6 +9,7 @@ route: '/reference/api'
 
 - [`renderHook`](/reference/api#renderhook)
 - [`act`](/reference/api#act)
+- [`cleanup`](/reference/api#cleanup)
 
 ---
 
@@ -102,3 +103,23 @@ A function to unmount the test component. This is commonly used to trigger clean
 
 This is the same [`act` function](https://reactjs.org/docs/test-utils.html#act) that is exported by
 `react-test-renderer`.
+
+---
+
+## `cleanup`
+
+Unmounts any rendered hooks rendered with `renderHook`, ensuring all effects have been flushed.
+
+> Please note that this is done automatically if the testing framework you're using supports the
+> `afterEach` global (like mocha, Jest, and Jasmine). If not, you will need to do manual cleanups
+> after each test.
+>
+> Setting the `RHTL_SKIP_AUTO_CLEANUP` environment variable to `true` before the
+> `@testing-library/react-hooks` is imported will disable this feature.
+
+```js
+async function cleanup: void
+```
+
+The `cleanup` function should be called after each test to ensure that previously rendered hooks
+will not have any unintended side-effects on the following tests.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -108,6 +108,10 @@ This is the same [`act` function](https://reactjs.org/docs/test-utils.html#act) 
 
 ## `cleanup`
 
+```js
+function cleanup: Promise<void>
+```
+
 Unmounts any rendered hooks rendered with `renderHook`, ensuring all effects have been flushed.
 
 > Please note that this is done automatically if the testing framework you're using supports the
@@ -116,10 +120,6 @@ Unmounts any rendered hooks rendered with `renderHook`, ensuring all effects hav
 >
 > Setting the `RHTL_SKIP_AUTO_CLEANUP` environment variable to `true` before the
 > `@testing-library/react-hooks` is imported will disable this feature.
-
-```js
-async function cleanup: void
-```
 
 The `cleanup` function should be called after each test to ensure that previously rendered hooks
 will not have any unintended side-effects on the following tests.

--- a/src/cleanup.js
+++ b/src/cleanup.js
@@ -1,0 +1,26 @@
+import { act } from 'react-test-renderer'
+
+let cleanupCallbacks = []
+
+async function cleanup() {
+  await act(async () => {})
+  cleanupCallbacks.forEach((cb) => cb())
+  cleanupCallbacks = []
+}
+
+function addCleanup(callback) {
+  cleanupCallbacks.push(callback)
+}
+
+function removeCleanup(callback) {
+  cleanupCallbacks = cleanupCallbacks.filter((cb) => cb !== callback)
+}
+
+// Automatically registers cleanup in supported testing frameworks
+if (typeof afterEach === 'function' && !process.env.RHTL_SKIP_AUTO_CLEANUP) {
+  afterEach(async () => {
+    await cleanup()
+  })
+}
+
+export { cleanup, addCleanup, removeCleanup }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 import React, { Suspense } from 'react'
 import { act, create } from 'react-test-renderer'
-
-let cleanupCallbacks = []
+import { cleanup, addCleanup, removeCleanup } from './cleanup'
 
 function TestHook({ callback, hookProps, onError, children }) {
   try {
@@ -77,12 +76,12 @@ function renderHook(callback, { initialProps, wrapper } = {}) {
 
   function unmountHook() {
     act(() => {
-      cleanupCallbacks = cleanupCallbacks.filter((cb) => cb !== unmountHook)
+      removeCleanup(unmountHook)
       unmount()
     })
   }
 
-  cleanupCallbacks.push(unmountHook)
+  addCleanup(unmountHook)
 
   let waitingForNextUpdate = null
   const resolveOnNextUpdate = (resolve) => {
@@ -106,20 +105,6 @@ function renderHook(callback, { initialProps, wrapper } = {}) {
     },
     unmount: unmountHook
   }
-}
-
-async function cleanup() {
-  await act(async () => {
-    await act(async () => {})
-    cleanupCallbacks.forEach((cb) => cb())
-    cleanupCallbacks = []
-  })
-}
-
-if (typeof afterEach === 'function' && !process.env.RHTL_SKIP_AUTO_CLEANUP) {
-  afterEach(async () => {
-    await cleanup()
-  })
 }
 
 export { renderHook, cleanup, act }

--- a/test/autoCleanup.disabled.test.js
+++ b/test/autoCleanup.disabled.test.js
@@ -1,0 +1,28 @@
+import { useEffect } from 'react'
+
+// This verifies that if RHTL_SKIP_AUTO_CLEANUP is set
+// then we DON'T auto-wire up the afterEach for folks
+describe('skip auto cleanup (disabled) tests', () => {
+  let cleanupCalled = false
+  let renderHook
+
+  beforeAll(() => {
+    process.env.RHTL_SKIP_AUTO_CLEANUP = 'true'
+    renderHook = require('src').renderHook
+  })
+
+  test('first', () => {
+    const hookWithCleanup = () => {
+      useEffect(() => {
+        return () => {
+          cleanupCalled = true
+        }
+      })
+    }
+    renderHook(() => hookWithCleanup())
+  })
+
+  test('second', () => {
+    expect(cleanupCalled).toBe(false)
+  })
+})

--- a/test/autoCleanup.noAfterEach.test.js
+++ b/test/autoCleanup.noAfterEach.test.js
@@ -1,0 +1,28 @@
+import { useEffect } from 'react'
+
+// This verifies that if RHTL_SKIP_AUTO_CLEANUP is set
+// then we DON'T auto-wire up the afterEach for folks
+describe('skip auto cleanup (no afterEach) tests', () => {
+  let cleanupCalled = false
+  let renderHook
+
+  beforeAll(() => {
+    afterEach = false
+    renderHook = require('src').renderHook
+  })
+
+  test('first', () => {
+    const hookWithCleanup = () => {
+      useEffect(() => {
+        return () => {
+          cleanupCalled = true
+        }
+      })
+    }
+    renderHook(() => hookWithCleanup())
+  })
+
+  test('second', () => {
+    expect(cleanupCalled).toBe(false)
+  })
+})

--- a/test/autoCleanup.test.js
+++ b/test/autoCleanup.test.js
@@ -1,0 +1,24 @@
+import { useEffect } from 'react'
+import { renderHook } from 'src'
+
+// This verifies that by importing RHTL in an
+// environment which supports afterEach (like jest)
+// we'll get automatic cleanup between tests.
+describe('auto cleanup tests', () => {
+  let cleanupCalled = false
+
+  test('first', () => {
+    const hookWithCleanup = () => {
+      useEffect(() => {
+        return () => {
+          cleanupCalled = true
+        }
+      })
+    }
+    renderHook(() => hookWithCleanup())
+  })
+
+  test('second', () => {
+    expect(cleanupCalled).toBe(true)
+  })
+})

--- a/test/cleanup.test.js
+++ b/test/cleanup.test.js
@@ -1,0 +1,41 @@
+import { useEffect } from 'react'
+import { renderHook, cleanup } from 'src'
+
+describe('cleanup tests', () => {
+  test('should flush effects on cleanup', async () => {
+    let cleanupCalled = false
+
+    const hookWithCleanup = () => {
+      useEffect(() => {
+        return () => {
+          cleanupCalled = true
+        }
+      })
+    }
+
+    renderHook(() => hookWithCleanup())
+
+    await cleanup()
+
+    expect(cleanupCalled).toBe(true)
+  })
+
+  test('should cleanup all rendered hooks', async () => {
+    let cleanupCalled = []
+    const hookWithCleanup = (id) => {
+      useEffect(() => {
+        return () => {
+          cleanupCalled[id] = true
+        }
+      })
+    }
+
+    renderHook(() => hookWithCleanup(1))
+    renderHook(() => hookWithCleanup(2))
+
+    await cleanup()
+
+    expect(cleanupCalled[1]).toBe(true)
+    expect(cleanupCalled[2]).toBe(true)
+  })
+})


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->


**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

Added cleanup functionality to unmount any rendered test components.

Resolved #76  

**Why**:

<!-- Why are these changes necessary? -->

Currently, the underlying rendered test component is not necessarily unmounted at the end of a test, resulting in effects from `useEffect` and `useLayoutEffect` hanging around between tests.

**How**:

<!-- How were these changes implemented? -->

The library now exports a global `cleanup` function that will unmount any rendered hooks.  As per [testing-library/react-testing-library#430](https://github.com/testing-library/react-testing-library/pull/430) we also auto regester an `afterEach` handler in supported test frameworks (with an environment variable opt out).

**Checklist**:

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove any items that are relevant to your changes
-->

- [x] Documentation updated
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
