### PR TITLE
Include missing "dont-cleanup-after-each" script in npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 [![downloads](https://img.shields.io/npm/dm/@testing-library/react-hooks.svg?style=flat-square)](http://www.npmtrends.com/@testing-library/react-hooks)
 [![MIT License](https://img.shields.io/npm/l/@testing-library/react-hooks.svg?style=flat-square)](https://github.com/testing-library/react-hooks-testing-library/blob/master/LICENSE.md)
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-13-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-13-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
 [![Code of Conduct](https://img.shields.io/badge/code%20of-conduct-ff69b4.svg?style=flat-square)](https://github.com/testing-library/react-hooks-testing-library/blob/master/CODE_OF_CONDUCT.md)
 [![Netlify Status](https://api.netlify.com/api/v1/badges/9a8f27a5-df38-4910-a248-4908b1ba29a7/deploy-status)](https://app.netlify.com/sites/react-hooks-testing-library/deploys)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lib",
     "src",
     "README.md",
-    "LICENSE.md"
+    "LICENSE.md",
+    "dont-cleanup-after-each.js"
   ],
   "author": "Michael Peyper <mpeyper7@gmail.com>",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,6 @@
   "files": [
     "lib",
     "src",
-    "README.md",
-    "LICENSE.md",
     "dont-cleanup-after-each.js"
   ],
   "author": "Michael Peyper <mpeyper7@gmail.com>",


### PR DESCRIPTION
**What**:

This adds the currently missing `dont-cleanup-after-each.js` file reference in `package.json` so that npm can pick it up and ship it within an upcoming release.

**Why**:

According to the docs (https://react-hooks-testing-library.com/reference/api#cleanup), it should be possible to set up this script via Jest config, but the file doesn't exist in the current package version (https://www.unpkg.com/browse/@testing-library/react-hooks@3.1.0/).

It also removes the redundant `README.md` and `LICENSE.md` from the `files` list as they are always included on `npm publish` (https://docs.npmjs.com/files/package.json#files).

**Checklist**:

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->