### PR TITLE
Add explanation for async state updates not needing to be wrapped in …

### DIFF
--- a/docs/usage/advanced-hooks.md
+++ b/docs/usage/advanced-hooks.md
@@ -132,6 +132,10 @@ test('should increment counter after delay', async () => {
 })
 ```
 
+Wrapping `incrementAsync` in `act()` is not necessary since the state updates happen
+asynchronously during `await waitForNextUpdate()`. The async utils automatically wrap the waiting
+code in the asynchronous `act()` wrapper.
+
 For more details on the the other async utilities, please refer to the
 [API Reference](/reference/api#async-utilities).
 

--- a/docs/usage/advanced-hooks.md
+++ b/docs/usage/advanced-hooks.md
@@ -133,8 +133,8 @@ test('should increment counter after delay', async () => {
 ```
 
 Wrapping `incrementAsync` in `act()` is not necessary since the state updates happen
-asynchronously during `await waitForNextUpdate()`. The async utils automatically wrap the waiting
-code in the asynchronous `act()` wrapper.
+asynchronously during `await waitForNextUpdate()`. The async utilities automatically wrap the
+waiting code in the asynchronous `act()` wrapper.
 
 For more details on the the other async utilities, please refer to the
 [API Reference](/reference/api#async-utilities).


### PR DESCRIPTION
…act()

**What**:

#283 Call to function that changes hook state not wrapped in `act()` in documentation example.

**Why**:

To clarify the difference in the required usage of `act()` between synchronous and non-synchronous test code.

**How**:

Explanatory text is added to the relevant documentation page.

**Checklist**:

- [x] Documentation updated
- [x] Ready to be merged
