### PR TITLE
docs: fix fragment identifier

### DIFF
--- a/docs/usage/advanced-hooks.md
+++ b/docs/usage/advanced-hooks.md
@@ -142,7 +142,7 @@ For more details on the the other async utilities, please refer to the
 ### Suspense
 
 All the [async utilities](/reference/api#async-utilities) will also wait for hooks that suspends
-using [React's `Suspense`](https://reactjs.org/docs/code-splitting.html#reactlazy) functionality to
+using [React's `Suspense`](https://reactjs.org/docs/react-api.html#reactsuspense) functionality to
 complete rendering.
 
 ## Errors

--- a/docs/usage/advanced-hooks.md
+++ b/docs/usage/advanced-hooks.md
@@ -142,7 +142,7 @@ For more details on the the other async utilities, please refer to the
 ### Suspense
 
 All the [async utilities](/reference/api#async-utilities) will also wait for hooks that suspends
-using [React's `Suspense`](https://reactjs.org/docs/code-splitting.html#suspense) functionality to
+using [React's `Suspense`](https://reactjs.org/docs/code-splitting.html#reactlazy) functionality to
 complete rendering.
 
 ## Errors


### PR DESCRIPTION

**What**:

Fix documentation.

**Why**:

Fragment identifier is incorrect.

**How**:

**Checklist**:

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Ready to be merged
