### PR TITLE
feature/use rerender props in wrapper

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -165,6 +165,15 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "hemlok",
+      "name": "Adam Seckel",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/9043345?v=4",
+      "profile": "https://github.com/hemlok",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
   <tr>
     <td align="center"><a href="http://frontstuff.io"><img src="https://avatars1.githubusercontent.com/u/5370675?v=4" width="100px;" alt=""/><br /><sub><b>Sarah Dayan</b></sub></a><br /><a href="#platform-sarahdayan" title="Packaging/porting to new platform">📦</a></td>
     <td align="center"><a href="https://github.com/102"><img src="https://avatars1.githubusercontent.com/u/5839225?v=4" width="100px;" alt=""/><br /><sub><b>Roman Gusev</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=102" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://github.com/hemlok"><img src="https://avatars2.githubusercontent.com/u/9043345?v=4" width="100px;" alt=""/><br /><sub><b>Adam Seckel</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=hemlok" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -46,12 +46,13 @@ The `renderHook` function accepts the following options as the second parameter:
 
 ### `initialProps`
 
-The initial values to pass as `props` to the `callback` function of `renderHook.
+The initial values to pass as `props` to the `callback` function of `renderHook`.
 
 ### `wrapper`
 
 A React component to wrap the test component in when rendering. This is usually used to add context
-providers from `React.createContext` for the hook to access with `useContext`.
+providers from `React.createContext` for the hook to access with `useContext`. `initialProps` and
+props subsequently set by `rerender` will be provided to the wrapper.
 
 ## `renderHook` Result
 

--- a/src/pure.js
+++ b/src/pure.js
@@ -58,7 +58,7 @@ function renderHook(callback, { initialProps, wrapper } = {}) {
   const hookProps = { current: initialProps }
 
   const wrapUiIfNeeded = (innerElement) =>
-    wrapper ? React.createElement(wrapper, null, innerElement) : innerElement
+    wrapper ? React.createElement(wrapper, hookProps.current, innerElement) : innerElement
 
   const toRender = () =>
     wrapUiIfNeeded(

--- a/test/useContext.test.js
+++ b/test/useContext.test.js
@@ -24,7 +24,7 @@ describe('useContext tests', () => {
     expect(result.current).toBe('bar')
   })
 
-  test('should update value in context', () => {
+  test('should update mutated value in context', () => {
     const TestContext = createContext('foo')
 
     const value = { current: 'bar' }
@@ -38,6 +38,25 @@ describe('useContext tests', () => {
     value.current = 'baz'
 
     rerender()
+
+    expect(result.current).toBe('baz')
+  })
+
+  test('should update value in context when props are updated', () => {
+    const TestContext = createContext('foo')
+
+    const wrapper = ({ current, children }) => (
+      <TestContext.Provider value={current}>{children}</TestContext.Provider>
+    )
+
+    const { result, rerender } = renderHook(() => useContext(TestContext), {
+      wrapper,
+      initialProps: {
+        current: 'bar'
+      }
+    })
+
+    rerender({ current: 'baz' })
 
     expect(result.current).toBe('baz')
   })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

Updates `renderHook` to pass props into a provided `wrapper` component. See discussion here: https://github.com/testing-library/react-hooks-testing-library/issues/322 w @mpeyper 

**Why**:

This allows easily testing how a hook response to changes in a parent context, without having to mutate values in test code.

**How**:

<!-- How were these changes implemented? -->

Pass the value of `hookProps.current` into render.

**Checklist**:

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
