### PR TITLE
Point-free examples

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -174,6 +174,16 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "flextremedev",
+      "name": "Pascal Wegner",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/16837852?v=4",
+      "profile": "https://github.com/flextremedev",
+      "contributions": [
+        "doc",
+        "example"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ import { renderHook, act } from '@testing-library/react-hooks'
 import useCounter from './useCounter'
 
 test('should increment counter', () => {
-  const { result } = renderHook(() => useCounter())
+  const { result } = renderHook(useCounter)
 
   act(() => {
     result.current.increment()
@@ -162,6 +162,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="http://frontstuff.io"><img src="https://avatars1.githubusercontent.com/u/5370675?v=4" width="100px;" alt=""/><br /><sub><b>Sarah Dayan</b></sub></a><br /><a href="#platform-sarahdayan" title="Packaging/porting to new platform">📦</a></td>
     <td align="center"><a href="https://github.com/102"><img src="https://avatars1.githubusercontent.com/u/5839225?v=4" width="100px;" alt=""/><br /><sub><b>Roman Gusev</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=102" title="Documentation">📖</a></td>
     <td align="center"><a href="https://github.com/hemlok"><img src="https://avatars2.githubusercontent.com/u/9043345?v=4" width="100px;" alt=""/><br /><sub><b>Adam Seckel</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=hemlok" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/flextremedev"><img src="https://avatars0.githubusercontent.com/u/16837852?v=4" width="100px;" alt=""/><br /><sub><b>Pascal Wegner</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=flextremedev" title="Documentation">📖</a> <a href="#example-flextremedev" title="Examples">💡</a></td>
   </tr>
 </table>
 

--- a/docs/usage/advanced-hooks.md
+++ b/docs/usage/advanced-hooks.md
@@ -41,7 +41,7 @@ import { CounterStepProvider, useCounter } from './counter'
 
 test('should use custom step when incrementing', () => {
   const wrapper = ({ children }) => <CounterStepProvider step={2}>{children}</CounterStepProvider>
-  const { result } = renderHook(() => useCounter(), { wrapper })
+  const { result } = renderHook(useCounter, { wrapper })
 
   act(() => {
     result.current.increment()
@@ -76,7 +76,7 @@ import { renderHook, act } from '@testing-library/react-hooks'
 import { CounterStepProvider, useCounter } from './counter'
 
 test('should use custom step when incrementing', () => {
-  const { result } = renderHook(() => useCounter(), {
+  const { result } = renderHook(useCounter, {
     wrapper: ({ children }) => <CounterStepProvider step={2}>{children}</CounterStepProvider>
   })
 
@@ -122,7 +122,7 @@ import { renderHook } from '@testing-library/react-hooks'
 import { useCounter } from './counter'
 
 test('should increment counter after delay', async () => {
-  const { result, waitForNextUpdate } = renderHook(() => useCounter())
+  const { result, waitForNextUpdate } = renderHook(useCounter)
 
   result.current.incrementAsync()
 

--- a/docs/usage/basic-hooks.md
+++ b/docs/usage/basic-hooks.md
@@ -28,7 +28,7 @@ import { renderHook } from '@testing-library/react-hooks'
 import useCounter from './useCounter'
 
 test('should use counter', () => {
-  const { result } = renderHook(() => useCounter())
+  const { result } = renderHook(useCounter)
 
   expect(result.current.count).toBe(0)
   expect(typeof result.current.increment).toBe('function')
@@ -48,7 +48,7 @@ import { renderHook, act } from '@testing-library/react-hooks'
 import useCounter from './useCounter'
 
 test('should increment counter', () => {
-  const { result } = renderHook(() => useCounter())
+  const { result } = renderHook(useCounter)
 
   act(() => {
     result.current.increment()


### PR DESCRIPTION
**What**:

Refactoring examples to use point-free definitions.

**Why**:

Many users tend to refer to the example and it might be useful for the example to be as clean as possible as in this case free of redundancy.

**How**:

Deleted wrapping functions and only left the function definition point-free.

**Checklist**:

- [x] Documentation updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table

This is my first open source contribution. Would be great to hear if I could do or could've done something better.