### PR TITLE
Add interval to async utilities to supplement post render checks

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -152,50 +152,36 @@ variable to `true` before importing `@testing-library/react-hooks` will also dis
 ### `waitForNextUpdate`
 
 ```js
-function waitForNextUpdate(options?: WaitOptions): Promise<void>
+function waitForNextUpdate(options?: {
+  timeout?: number
+}): Promise<void>
 ```
 
 Returns a `Promise` that resolves the next time the hook renders, commonly when state is updated as
 the result of an asynchronous update.
 
-See the [`wait` Options](/reference/api#wait-options) section for more details on the available
-`options`.
+#### `timeout`
 
-### `wait`
+The maximum amount of time in milliseconds (ms) to wait. By default, no timeout is applied.
+
+### `waitFor`
 
 ```js
-function wait(callback: function(): boolean|void, options?: WaitOptions): Promise<void>
+function waitFor(callback: function(): boolean|void, options?: {
+  interval?: number,
+  timeout?: number,
+  suppressErrors?: boolean
+}): Promise<void>
 ```
 
 Returns a `Promise` that resolves if the provided callback executes without exception and returns a
 truthy or `undefined` value. It is safe to use the [`result` of `renderHook`](/reference/api#result)
 in the callback to perform assertion or to test values.
 
-The callback is tested after each render of the hook. By default, errors raised from the callback
-will be suppressed (`suppressErrors = true`).
+#### `interval`
 
-See the [`wait` Options](/reference/api#wait-options) section for more details on the available
-`options`.
-
-### `waitForValueToChange`
-
-```js
-function waitForValueToChange(selector: function(): any, options?: WaitOptions): Promise<void>
-```
-
-Returns a `Promise` that resolves if the value returned from the provided selector changes. It
-expected that the [`result` of `renderHook`](/reference/api#result) to select the value for
-comparison.
-
-The value is selected for comparison after each render of the hook. By default, errors raised from
-selecting the value will not be suppressed (`suppressErrors = false`).
-
-See the [`wait` Options](/reference/api#wait-options) section for more details on the available
-`options`.
-
-### `wait` Options
-
-The async utilities accept the following options:
+The amount of time in milliseconds (ms) to wait between checks of the callback if no renders occur.
+By default, an interval of 50ms is used.
 
 #### `timeout`
 
@@ -205,5 +191,58 @@ The maximum amount of time in milliseconds (ms) to wait. By default, no timeout 
 
 If this option is set to `true`, any errors that occur while waiting are treated as a failed check.
 If this option is set to `false`, any errors that occur while waiting cause the promise to be
-rejected. Please refer to the [utility descriptions](/reference/api#async-utilities) for the default
-values of this option (if applicable).
+rejected. By default, errors are suppressed for this utility.
+
+### `waitForValueToChange`
+
+```js
+function waitForValueToChange(selector: function(): any, options?: {
+  interval?: number,
+  timeout?: number,
+  suppressErrors?: boolean
+}): Promise<void>
+```
+
+Returns a `Promise` that resolves if the value returned from the provided selector changes. It
+expected that the [`result` of `renderHook`](/reference/api#result) to select the value for
+comparison.
+
+#### `interval`
+
+The amount of time in milliseconds (ms) to wait between checks of the callback if no renders occur.
+By default, an interval of 50ms is used.
+
+#### `timeout`
+
+The maximum amount of time in milliseconds (ms) to wait. By default, no timeout is applied.
+
+#### `suppressErrors`
+
+If this option is set to `true`, any errors that occur while waiting are treated as a failed check.
+If this option is set to `false`, any errors that occur while waiting cause the promise to be
+rejected. By default, errors are not suppressed for this utility.
+
+### `wait`
+
+_(DEPRECATED, use [`waitFor`](/reference/api#waitFor) instead)_
+
+```js
+function waitFor(callback: function(): boolean|void, options?: {
+  timeout?: number,
+  suppressErrors?: boolean
+}): Promise<void>
+```
+
+Returns a `Promise` that resolves if the provided callback executes without exception and returns a
+truthy or `undefined` value. It is safe to use the [`result` of `renderHook`](/reference/api#result)
+in the callback to perform assertion or to test values.
+
+#### `timeout`
+
+The maximum amount of time in milliseconds (ms) to wait. By default, no timeout is applied.
+
+#### `suppressErrors`
+
+If this option is set to `true`, any errors that occur while waiting are treated as a failed check.
+If this option is set to `false`, any errors that occur while waiting cause the promise to be
+rejected. By default, errors are suppressed for this utility.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -181,7 +181,8 @@ in the callback to perform assertion or to test values.
 #### `interval`
 
 The amount of time in milliseconds (ms) to wait between checks of the callback if no renders occur.
-By default, an interval of 50ms is used.
+Interval checking is disabled if `interval` is not provided in the options or provided as a `falsy`
+value. By default, it is disabled.
 
 #### `timeout`
 
@@ -210,7 +211,8 @@ comparison.
 #### `interval`
 
 The amount of time in milliseconds (ms) to wait between checks of the callback if no renders occur.
-By default, an interval of 50ms is used.
+Interval checking is disabled if `interval` is not provided in the options or provided as a `falsy`
+value. By default, it is disabled.
 
 #### `timeout`
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -224,7 +224,7 @@ rejected. By default, errors are not suppressed for this utility.
 
 ### `wait`
 
-_(DEPRECATED, use [`waitFor`](/reference/api#waitFor) instead)_
+_(DEPRECATED, use [`waitFor`](/reference/api#waitfor) instead)_
 
 ```js
 function waitFor(callback: function(): boolean|void, options?: {

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -227,7 +227,7 @@ rejected. By default, errors are not suppressed for this utility.
 _(DEPRECATED, use [`waitFor`](/reference/api#waitfor) instead)_
 
 ```js
-function waitFor(callback: function(): boolean|void, options?: {
+function wait(callback: function(): boolean|void, options?: {
   timeout?: number,
   suppressErrors?: boolean
 }): Promise<void>

--- a/src/asyncUtils.js
+++ b/src/asyncUtils.js
@@ -38,7 +38,7 @@ function asyncUtils(addResolver) {
     await nextUpdatePromise
   }
 
-  const waitFor = async (callback, { interval = 50, timeout, suppressErrors = true } = {}) => {
+  const waitFor = async (callback, { interval, timeout, suppressErrors = true } = {}) => {
     const checkResult = () => {
       try {
         const callbackResult = callback()
@@ -55,7 +55,12 @@ function asyncUtils(addResolver) {
       while (true) {
         const startTime = Date.now()
         try {
-          await Promise.race([waitForNextUpdate({ timeout }), resolveAfter(interval)])
+          const nextCheck = interval
+            ? Promise.race([waitForNextUpdate({ timeout }), resolveAfter(interval)])
+            : waitForNextUpdate({ timeout })
+
+          await nextCheck
+
           if (checkResult()) {
             return
           }

--- a/src/asyncUtils.js
+++ b/src/asyncUtils.js
@@ -93,7 +93,7 @@ function asyncUtils(addResolver) {
     if (!hasWarnedDeprecatedWait) {
       hasWarnedDeprecatedWait = true
       console.warn(
-        '`wait` has been deprecated. Use `waitFor` instead: https://react-hooks-testing-library.com/reference/api#waitFor.'
+        '`wait` has been deprecated. Use `waitFor` instead: https://react-hooks-testing-library.com/reference/api#waitfor.'
       )
     }
     try {

--- a/src/asyncUtils.js
+++ b/src/asyncUtils.js
@@ -6,6 +6,14 @@ function createTimeoutError(utilName, { timeout }) {
   return timeoutError
 }
 
+function resolveAfter(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+let hasWarnedDeprecatedWait = false
+
 function asyncUtils(addResolver) {
   let nextUpdatePromise = null
 
@@ -30,7 +38,7 @@ function asyncUtils(addResolver) {
     await nextUpdatePromise
   }
 
-  const wait = async (callback, { timeout, suppressErrors = true } = {}) => {
+  const waitFor = async (callback, { interval = 50, timeout, suppressErrors = true } = {}) => {
     const checkResult = () => {
       try {
         const callbackResult = callback()
@@ -47,13 +55,13 @@ function asyncUtils(addResolver) {
       while (true) {
         const startTime = Date.now()
         try {
-          await waitForNextUpdate({ timeout })
+          await Promise.race([waitForNextUpdate({ timeout }), resolveAfter(interval)])
           if (checkResult()) {
             return
           }
         } catch (e) {
           if (e.timeout) {
-            throw createTimeoutError('wait', { timeout: initialTimeout })
+            throw createTimeoutError('waitFor', { timeout: initialTimeout })
           }
           throw e
         }
@@ -69,7 +77,7 @@ function asyncUtils(addResolver) {
   const waitForValueToChange = async (selector, options = {}) => {
     const initialValue = selector()
     try {
-      await wait(() => selector() !== initialValue, {
+      await waitFor(() => selector() !== initialValue, {
         suppressErrors: false,
         ...options
       })
@@ -81,8 +89,26 @@ function asyncUtils(addResolver) {
     }
   }
 
+  const wait = async (callback, { timeout, suppressErrors } = {}) => {
+    if (!hasWarnedDeprecatedWait) {
+      hasWarnedDeprecatedWait = true
+      console.warn(
+        '`wait` has been deprecated. Use `waitFor` instead: https://react-hooks-testing-library.com/reference/api#waitFor.'
+      )
+    }
+    try {
+      await waitFor(callback, { timeout, suppressErrors })
+    } catch (e) {
+      if (e.timeout) {
+        throw createTimeoutError('wait', { timeout })
+      }
+      throw e
+    }
+  }
+
   return {
     wait,
+    waitFor,
     waitForNextUpdate,
     waitForValueToChange
   }

--- a/test/asyncHook.test.js
+++ b/test/asyncHook.test.js
@@ -280,28 +280,6 @@ describe('async hook tests', () => {
     expect(complete).toBe(true)
   })
 
-  test('should wait for arbitrary expectation to pass (deprecated)', async () => {
-    const { wait } = renderHook(() => null)
-
-    let actual = 0
-    let expected = 1
-
-    setTimeout(() => {
-      actual = expected
-    }, 200)
-
-    let complete = false
-    await wait(
-      () => {
-        expect(actual).toBe(expected)
-        complete = true
-      },
-      { interval: 100 }
-    )
-
-    expect(complete).toBe(true)
-  })
-
   test('should not hang if expectation is already passing (deprecated)', async () => {
     const { result, wait } = renderHook(() => useSequence('first', 'second'))
 

--- a/test/asyncHook.test.js
+++ b/test/asyncHook.test.js
@@ -67,25 +67,47 @@ describe('async hook tests', () => {
   })
 
   test('should wait for expectation to pass', async () => {
-    const { result, wait } = renderHook(() => useSequence('first', 'second', 'third'))
+    const { result, waitFor } = renderHook(() => useSequence('first', 'second', 'third'))
 
     expect(result.current).toBe('first')
 
     let complete = false
-    await wait(() => {
+    await waitFor(() => {
       expect(result.current).toBe('third')
       complete = true
     })
     expect(complete).toBe(true)
   })
 
+  test('should wait for arbitrary expectation to pass', async () => {
+    const { waitFor } = renderHook(() => null)
+
+    let actual = 0
+    let expected = 1
+
+    setTimeout(() => {
+      actual = expected
+    }, 200)
+
+    let complete = false
+    await waitFor(
+      () => {
+        expect(actual).toBe(expected)
+        complete = true
+      },
+      { interval: 100 }
+    )
+
+    expect(complete).toBe(true)
+  })
+
   test('should not hang if expectation is already passing', async () => {
-    const { result, wait } = renderHook(() => useSequence('first', 'second'))
+    const { result, waitFor } = renderHook(() => useSequence('first', 'second'))
 
     expect(result.current).toBe('first')
 
     let complete = false
-    await wait(() => {
+    await waitFor(() => {
       expect(result.current).toBe('first')
       complete = true
     })
@@ -93,12 +115,12 @@ describe('async hook tests', () => {
   })
 
   test('should reject if callback throws error', async () => {
-    const { result, wait } = renderHook(() => useSequence('first', 'second', 'third'))
+    const { result, waitFor } = renderHook(() => useSequence('first', 'second', 'third'))
 
     expect(result.current).toBe('first')
 
     await expect(
-      wait(
+      waitFor(
         () => {
           if (result.current === 'second') {
             throw new Error('Something Unexpected')
@@ -113,12 +135,12 @@ describe('async hook tests', () => {
   })
 
   test('should reject if callback immediately throws error', async () => {
-    const { result, wait } = renderHook(() => useSequence('first', 'second', 'third'))
+    const { result, waitFor } = renderHook(() => useSequence('first', 'second', 'third'))
 
     expect(result.current).toBe('first')
 
     await expect(
-      wait(
+      waitFor(
         () => {
           throw new Error('Something Unexpected')
         },
@@ -130,28 +152,43 @@ describe('async hook tests', () => {
   })
 
   test('should wait for truthy value', async () => {
-    const { result, wait } = renderHook(() => useSequence('first', 'second', 'third'))
+    const { result, waitFor } = renderHook(() => useSequence('first', 'second', 'third'))
 
     expect(result.current).toBe('first')
 
-    await wait(() => result.current === 'third')
+    await waitFor(() => result.current === 'third')
 
     expect(result.current).toBe('third')
   })
 
+  test('should wait for arbitrary truthy value', async () => {
+    const { waitFor } = renderHook(() => null)
+
+    let actual = 0
+    let expected = 1
+
+    setTimeout(() => {
+      actual = expected
+    }, 200)
+
+    await waitFor(() => actual === 1, { interval: 100 })
+
+    expect(actual).toBe(expected)
+  })
+
   test('should reject if timeout exceeded when waiting for expectation to pass', async () => {
-    const { result, wait } = renderHook(() => useSequence('first', 'second', 'third'))
+    const { result, waitFor } = renderHook(() => useSequence('first', 'second', 'third'))
 
     expect(result.current).toBe('first')
 
     await expect(
-      wait(
+      waitFor(
         () => {
           expect(result.current).toBe('third')
         },
         { timeout: 75 }
       )
-    ).rejects.toThrow(Error('Timed out in wait after 75ms.'))
+    ).rejects.toThrow(Error('Timed out in waitFor after 75ms.'))
   })
 
   test('should wait for value to change', async () => {
@@ -164,6 +201,21 @@ describe('async hook tests', () => {
     await waitForValueToChange(() => result.current === 'third')
 
     expect(result.current).toBe('third')
+  })
+
+  test('should wait for arbitrary value to change', async () => {
+    const { waitForValueToChange } = renderHook(() => null)
+
+    let actual = 0
+    let expected = 1
+
+    setTimeout(() => {
+      actual = expected
+    }, 200)
+
+    await waitForValueToChange(() => actual, { interval: 100 })
+
+    expect(actual).toBe(expected)
   })
 
   test('should reject if timeout exceeded when waiting for value to change', async () => {
@@ -213,5 +265,115 @@ describe('async hook tests', () => {
     )
 
     expect(result.current).toBe('third')
+  })
+
+  test('should wait for expectation to pass (deprecated)', async () => {
+    const { result, wait } = renderHook(() => useSequence('first', 'second', 'third'))
+
+    expect(result.current).toBe('first')
+
+    let complete = false
+    await wait(() => {
+      expect(result.current).toBe('third')
+      complete = true
+    })
+    expect(complete).toBe(true)
+  })
+
+  test('should wait for arbitrary expectation to pass (deprecated)', async () => {
+    const { wait } = renderHook(() => null)
+
+    let actual = 0
+    let expected = 1
+
+    setTimeout(() => {
+      actual = expected
+    }, 200)
+
+    let complete = false
+    await wait(
+      () => {
+        expect(actual).toBe(expected)
+        complete = true
+      },
+      { interval: 100 }
+    )
+
+    expect(complete).toBe(true)
+  })
+
+  test('should not hang if expectation is already passing (deprecated)', async () => {
+    const { result, wait } = renderHook(() => useSequence('first', 'second'))
+
+    expect(result.current).toBe('first')
+
+    let complete = false
+    await wait(() => {
+      expect(result.current).toBe('first')
+      complete = true
+    })
+    expect(complete).toBe(true)
+  })
+
+  test('should reject if callback throws error (deprecated)', async () => {
+    const { result, wait } = renderHook(() => useSequence('first', 'second', 'third'))
+
+    expect(result.current).toBe('first')
+
+    await expect(
+      wait(
+        () => {
+          if (result.current === 'second') {
+            throw new Error('Something Unexpected')
+          }
+          return result.current === 'third'
+        },
+        {
+          suppressErrors: false
+        }
+      )
+    ).rejects.toThrow(Error('Something Unexpected'))
+  })
+
+  test('should reject if callback immediately throws error (deprecated)', async () => {
+    const { result, wait } = renderHook(() => useSequence('first', 'second', 'third'))
+
+    expect(result.current).toBe('first')
+
+    await expect(
+      wait(
+        () => {
+          throw new Error('Something Unexpected')
+        },
+        {
+          suppressErrors: false
+        }
+      )
+    ).rejects.toThrow(Error('Something Unexpected'))
+  })
+
+  test('should wait for truthy value (deprecated)', async () => {
+    const { result, wait } = renderHook(() => useSequence('first', 'second', 'third'))
+
+    expect(result.current).toBe('first')
+
+    await wait(() => result.current === 'third')
+
+    expect(result.current).toBe('third')
+  })
+
+  test('should reject if timeout exceeded when waiting for expectation to pass (deprecated)', async () => {
+    const { result, wait } = renderHook(() => useSequence('first', 'second', 'third'))
+
+    expect(result.current).toBe('first')
+
+    await expect(
+      wait(
+        () => {
+          expect(result.current).toBe('third')
+        },
+        { timeout: 75 }
+      )
+    ).rejects.toThrow(Error('Timed out in wait after 75ms.'))
   })
 })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

Resolves #241
Resolves #393 

**Why**:

<!-- Why are these changes necessary? -->

If hooks don't render the checks don't run.  This makes waiting for side effects or other changes outside of the hook's render lifecycle more difficult.

**How**:

<!-- How were these changes implemented? -->

* Replace `wait` with `waitFor`
* Introduces an `interval` option to `waitFor` and `waitForValueToChange`
  * check callbacks run after interval time if no renders have occurred since last check

**Checklist**:

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

~I'm having some issues generating the docs to check the changes there.  There appears to be an issue with one of dependencies of `docz` but I have yet to look into it more closely.~ These seems to only be an issue locally.  The Netlify preview is generating fine 🤷‍♂️ 

~I'm also thinking about allowing the functionality to by passing a `falsy` value and using this as the default, making this a non breaking change.  We could follow this up with a breaking release that removes `wait` and changes the default for `interval` to be `50ms`.  I've also wanted to change the default `timeout` to `1000ms` for a while now, so I'd probably bundle that into the breaking change too.~ I've made it opt in for the initial release.  Will follow up with a breaking release which enables it by default, adds a default timeout and removed the deprecated `wait` utility.