### PR TITLE
Update `@types/testing-library__react-hooks` dependency version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3696,9 +3696,9 @@
       }
     },
     "@types/react-test-renderer": {
-      "version": "16.9.2",
-      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-16.9.2.tgz",
-      "integrity": "sha512-4eJr1JFLIAlWhzDkBCkhrOIWOvOxcCAfQh+jiKg7l/nNZcCIL2MHl2dZhogIFKyHzedVWHaVP1Yydq/Ruu4agw==",
+      "version": "16.9.3",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-16.9.3.tgz",
+      "integrity": "sha512-wJ7IlN5NI82XMLOyHSa+cNN4Z0I+8/YaLl04uDgcZ+W+ExWCmCiVTLT/7fRNqzy4OhStZcUwIqLNF7q+AdW43Q==",
       "requires": {
         "@types/react": "*"
       }
@@ -3720,11 +3720,10 @@
       "dev": true
     },
     "@types/testing-library__react-hooks": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.3.0.tgz",
-      "integrity": "sha512-ZbMmXaVqeiLjbRGEXuDeh6fG2hkNxaOiXV7o9RklXwKeSrygx0aohuomnkWi7UobJUhkvGZLFUmsoirfGY8HPw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.4.0.tgz",
+      "integrity": "sha512-QYLZipqt1hpwYsBU63Ssa557v5wWbncqL36No59LI7W3nCMYKrLWTnYGn2griZ6v/3n5nKXNYkTeYpqPHY7Ukg==",
       "requires": {
-        "@types/react": "*",
         "@types/react-test-renderer": "*"
       }
     },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.5.4",
-    "@types/testing-library__react-hooks": "^3.3.0"
+    "@types/testing-library__react-hooks": "^3.4.0"
   },
   "devDependencies": {
     "@babel/cli": "7.11.6",


### PR DESCRIPTION
**What**:

Update the version of dependency `@types/testing-library__react-hooks`

**Why**:

In 3.3.0, there's no type definition of `waitFor`, so in my project I have to use the deprecated `wait` instead.

**How**:

Run `npm update @types/testing-library__react-hooks`

**Checklist**:

- [x] Documentation updated
- [x] Tests
- [x] Ready to be merged
- [ ] Added myself to contributors table
