### PR TITLE
pr/docs-fix-links

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -183,6 +183,15 @@
       "contributions": [
         "test"
       ]
+    },
+    {
+      "login": "gortron",
+      "name": "Gordy Lanza",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/6877497?v=4",
+      "profile": "https://www.gordonlanza.com/",
+      "contributions": [
+        "doc"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -164,11 +164,13 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/102"><img src="https://avatars1.githubusercontent.com/u/5839225?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Roman Gusev</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=102" title="Documentation">📖</a></td>
     <td align="center"><a href="https://github.com/hemlok"><img src="https://avatars2.githubusercontent.com/u/9043345?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Adam Seckel</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=hemlok" title="Code">💻</a></td>
     <td align="center"><a href="https://keiya01.github.io/portfolio"><img src="https://avatars1.githubusercontent.com/u/34934510?v=4?s=100" width="100px;" alt=""/><br /><sub><b>keiya sasaki</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=keiya01" title="Tests">⚠️</a></td>
+    <td align="center"><a href="https://www.gordonlanza.com/"><img src="https://avatars3.githubusercontent.com/u/6877497?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Gordy Lanza</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=gortron" title="Documentation">📖</a></td>
   </tr>
 </table>
 
-<!-- markdownlint-enable -->
+<!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://allcontributors.org/) specification.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,15 +1,15 @@
 ---
 name: API Reference
-route: '/reference/api'
+route: '/docs/api-reference'
 ---
 
 # API
 
 `react-hooks-testing-library` exports the following methods:
 
-- [`renderHook`](/reference/api#renderhook)
-- [`act`](/reference/api#act)
-- [`cleanup`](/reference/api#cleanup)
+- [`renderHook`](/docs/api-reference.md#renderhook)
+- [`act`](/docs/api-reference.md#act)
+- [`cleanup`](/docs/api-reference.md#cleanup)
 
 ---
 
@@ -38,7 +38,7 @@ The `props` passed into the callback will be the `initialProps` provided in the 
 ### `options` (Optional)
 
 An options object to modify the execution of the `callback` function. See the
-[`renderHook` Options](/reference/api#renderhook-options) section for more details.
+[`renderHook` Options](/docs/api-reference.md#renderhook-options) section for more details.
 
 ## `renderHook` Options
 
@@ -91,7 +91,7 @@ A function to unmount the test component. This is commonly used to trigger clean
 ### `...asyncUtils`
 
 Utilities to assist with testing asynchronous behaviour. See the
-[Async Utils](/reference/api#async-utilities) section for more details.
+[Async Utils](/docs/api-reference.md#async-utilities) section for more details.
 
 ---
 
@@ -175,8 +175,9 @@ function waitFor(callback: function(): boolean|void, options?: {
 ```
 
 Returns a `Promise` that resolves if the provided callback executes without exception and returns a
-truthy or `undefined` value. It is safe to use the [`result` of `renderHook`](/reference/api#result)
-in the callback to perform assertion or to test values.
+truthy or `undefined` value. It is safe to use the
+[`result` of `renderHook`](/docs/api-reference.md#result) in the callback to perform assertion or to
+test values.
 
 #### `interval`
 
@@ -205,7 +206,7 @@ function waitForValueToChange(selector: function(): any, options?: {
 ```
 
 Returns a `Promise` that resolves if the value returned from the provided selector changes. It
-expected that the [`result` of `renderHook`](/reference/api#result) to select the value for
+expected that the [`result` of `renderHook`](/docs/api-reference.md#result) to select the value for
 comparison.
 
 #### `interval`
@@ -226,7 +227,7 @@ rejected. By default, errors are not suppressed for this utility.
 
 ### `wait`
 
-_(DEPRECATED, use [`waitFor`](/reference/api#waitfor) instead)_
+_(DEPRECATED, use [`waitFor`](/docs/api-reference.md#waitfor) instead)_
 
 ```js
 function wait(callback: function(): boolean|void, options?: {
@@ -236,8 +237,9 @@ function wait(callback: function(): boolean|void, options?: {
 ```
 
 Returns a `Promise` that resolves if the provided callback executes without exception and returns a
-truthy or `undefined` value. It is safe to use the [`result` of `renderHook`](/reference/api#result)
-in the callback to perform assertion or to test values.
+truthy or `undefined` value. It is safe to use the
+[`result` of `renderHook`](/docs/api-reference.md#result) in the callback to perform assertion or to
+test values.
 
 #### `timeout`
 

--- a/docs/usage/advanced-hooks.md
+++ b/docs/usage/advanced-hooks.md
@@ -1,7 +1,7 @@
 ---
 name: Advanced Hooks
 menu: Usage
-route: '/usage/advanced-hooks'
+route: '/docs/usage/advanced-hooks'
 ---
 
 # Advanced Hooks
@@ -12,8 +12,8 @@ Often, a hook is going to need a value out of context. The `useContext` hook is 
 this, but it will often require a `Provider` to be wrapped around the component using the hook. We
 can use the `wrapper` option for `renderHook` to do just that.
 
-Let's change the `useCounter` example from the [Basic Hooks section](/usage/basic-hooks) to get a
-`step` value from context and build a `CounterStepProvider` that allows us to set the value:
+Let's change the `useCounter` example from the [Basic Hooks section](/docs/usage/basic-hooks.md) to
+get a `step` value from context and build a `CounterStepProvider` that allows us to set the value:
 
 ```js
 import React, { useState, useContext, useCallback } from 'react'
@@ -179,13 +179,13 @@ during `await waitForNextUpdate()`. The async utilities automatically wrap the w
 asynchronous `act()` wrapper.
 
 For more details on the other async utilities, please refer to the
-[API Reference](/reference/api#asyncutils).
+[API Reference](/docs/api-reference.md#asyncutils).
 
 ### Suspense
 
-All the [async utilities](/reference/api#async-utilities) will also wait for hooks that suspend
-using [React's `Suspense`](https://reactjs.org/docs/react-api.html#reactsuspense) functionality to
-complete rendering.
+All the [async utilities](/docs/api-reference.md#async-utilities) will also wait for hooks that
+suspend using [React's `Suspense`](https://reactjs.org/docs/react-api.html#reactsuspense)
+functionality to complete rendering.
 
 ## Errors
 

--- a/docs/usage/basic-hooks.md
+++ b/docs/usage/basic-hooks.md
@@ -1,7 +1,7 @@
 ---
 name: Basic Hooks
 menu: Usage
-route: '/usage/basic-hooks'
+route: '/docs/usage/basic-hooks'
 ---
 
 # Basic Hooks


### PR DESCRIPTION
**What**:

Some links in the documentation were broken, giving user's browsing the documentation on GitHub a 404 error.

The links are working fine as is on your [documentation site](https://react-hooks-testing-library.com/), they are only broken on GitHub. It's possible these fixes will causes issues there. If that's the case, please feel free to reject and close this PR.

**Why**:

Fixing the links makes it easier for people to browse the documentation.

**How**:

The links are fixed by updating their routes where necessary. 

**Checklist**:

- [ x ] Documentation updated
- [ x ] Added myself to contributors table


