### PR TITLE
fix: ReactHooksRenderer renderHook was not expecting arguments

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,5 +1,5 @@
-import { CreateRenderer, Renderer, RenderResult, RenderHook } from '../types'
-import { ResultContainer, RenderHookOptions } from '../types/internal'
+import { CreateRenderer, Renderer, RenderResult, RenderHook, RenderHookOptions } from '../types'
+import { ResultContainer } from '../types/internal'
 
 import asyncUtils from './asyncUtils'
 import { cleanup, addCleanup, removeCleanup } from './cleanup'

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,5 @@
+import { RenderHookOptions } from './internal'
+
 export type Renderer<TProps> = {
   render: (props?: TProps) => void
   rerender: (props?: TProps) => void
@@ -48,7 +50,10 @@ export type RenderHook<
   AsyncUtils
 
 export interface ReactHooksRenderer {
-  renderHook: <TProps, TResult>() => RenderHook<TProps, TResult>
+  renderHook: <TProps, TResult, TOptions>(
+    callback: (props: TProps) => TResult,
+    options?: RenderHookOptions<TProps, TOptions>
+  ) => RenderHook<TProps, TResult>
   act: Act
   cleanup: () => void
   addCleanup: (callback: () => Promise<void> | void) => () => void

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,3 @@
-import { RenderHookOptions } from './internal'
-
 export type Renderer<TProps> = {
   render: (props?: TProps) => void
   rerender: (props?: TProps) => void
@@ -58,6 +56,10 @@ export interface ReactHooksRenderer {
   cleanup: () => void
   addCleanup: (callback: () => Promise<void> | void) => () => void
   removeCleanup: (callback: () => Promise<void> | void) => void
+}
+
+export type RenderHookOptions<TProps, TOptions extends {}> = TOptions & {
+  initialProps?: TProps
 }
 
 export interface Act {

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -6,7 +6,3 @@ export type ResultContainer<TValue> = {
   setValue: (val: TValue) => void
   setError: (error: Error) => void
 }
-
-export type RenderHookOptions<TProps, TOptions extends {}> = TOptions & {
-  initialProps?: TProps
-}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

ReactHooksRenderer was not expecting arguments due to `src/pure` missing those args in the `renderhook` function

**Why**:

<!-- Why are these changes necessary? -->

fixes TS errors

**How**:

<!-- How were these changes implemented? -->

**Checklist**:

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
