### PR TITLE
fix: Type for options in autodetected renderer was incorrectly inferring any passed type

### DIFF
--- a/src/pure.ts
+++ b/src/pure.ts
@@ -1,4 +1,4 @@
-import { ReactHooksRenderer } from './types'
+import { ReactHooksRenderer } from './types/react'
 
 const renderers = [
   { required: 'react-test-renderer', renderer: './native/pure' },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -47,17 +47,6 @@ export type RenderHook<
   Omit<TRenderer, keyof Renderer<TProps>> &
   AsyncUtils
 
-export interface ReactHooksRenderer {
-  renderHook: <TProps, TResult, TOptions>(
-    callback: (props: TProps) => TResult,
-    options?: RenderHookOptions<TProps, TOptions>
-  ) => RenderHook<TProps, TResult>
-  act: Act
-  cleanup: () => void
-  addCleanup: (callback: () => Promise<void> | void) => () => void
-  removeCleanup: (callback: () => Promise<void> | void) => void
-}
-
 export type RenderHookOptions<TProps, TOptions extends {}> = TOptions & {
   initialProps?: TProps
 }

--- a/src/types/react.ts
+++ b/src/types/react.ts
@@ -1,7 +1,20 @@
 import { ComponentType } from 'react'
 
+import { RenderHook, RenderHookOptions, Act } from '.'
+
 export type WrapperComponent<TProps> = ComponentType<TProps>
 
 export type RendererOptions<TProps> = {
   wrapper?: WrapperComponent<TProps>
+}
+
+export interface ReactHooksRenderer {
+  renderHook: <TProps, TResult>(
+    callback: (props: TProps) => TResult,
+    options?: RenderHookOptions<TProps, RendererOptions<TProps>>
+  ) => RenderHook<TProps, TResult>
+  act: Act
+  cleanup: () => void
+  addCleanup: (callback: () => Promise<void> | void) => () => void
+  removeCleanup: (callback: () => Promise<void> | void) => void
 }

--- a/test/dom/autoCleanup.disabled.ts
+++ b/test/dom/autoCleanup.disabled.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 
-import { ReactHooksRenderer } from 'types'
+import { ReactHooksRenderer } from 'types/react'
 
 // This verifies that if RHTL_SKIP_AUTO_CLEANUP is set
 // then we DON'T auto-wire up the afterEach for folks

--- a/test/dom/autoCleanup.noAfterEach.ts
+++ b/test/dom/autoCleanup.noAfterEach.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 
-import { ReactHooksRenderer } from 'types'
+import { ReactHooksRenderer } from 'types/react'
 
 // This verifies that if RHTL_SKIP_AUTO_CLEANUP is set
 // then we DON'T auto-wire up the afterEach for folks


### PR DESCRIPTION
Changed `renderHook` in `ReactHooksRenderer` type to not use a generic for options but rather the react specific `RendererOptions`.

Moved `ReactHooksRenderer` into react specific types as all auto-detected renders are react renderers.  All modules are currently exporting both the shared types and the react types so this a non-breaking change.

**Checklist**:

- [x] Ready to be merged
