### PR TITLE
Refactor beta branch for a bit more consistency

### DIFF
--- a/src/core/asyncUtils.ts
+++ b/src/core/asyncUtils.ts
@@ -95,4 +95,4 @@ function asyncUtils(act: Act, addResolver: (callback: () => void) => void): Asyn
   }
 }
 
-export default asyncUtils
+export { asyncUtils }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,7 +1,7 @@
 import { CreateRenderer, Renderer, RenderResult, RenderHook, RenderHookOptions } from '../types'
 import { ResultContainer } from '../types/internal'
 
-import asyncUtils from './asyncUtils'
+import { asyncUtils } from './asyncUtils'
 import { cleanup, addCleanup, removeCleanup } from './cleanup'
 
 function resultContainer<TValue>(): ResultContainer<TValue> {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -43,10 +43,10 @@ function resultContainer<TValue>(): ResultContainer<TValue> {
 function createRenderHook<TProps, TResult, TOptions extends {}, TRenderer extends Renderer<TProps>>(
   createRenderer: CreateRenderer<TProps, TResult, TOptions, TRenderer>
 ) {
-  return function renderHook(
+  const renderHook = (
     callback: (props: TProps) => TResult,
     options: RenderHookOptions<TProps, TOptions> = {} as RenderHookOptions<TProps, TOptions>
-  ): RenderHook<TProps, TResult, TRenderer> {
+  ): RenderHook<TProps, TResult, TRenderer> => {
     const { result, setValue, setError, addResolver } = resultContainer<TResult>()
     const renderProps = { callback, setValue, setError }
     let hookProps = options.initialProps
@@ -75,6 +75,13 @@ function createRenderHook<TProps, TResult, TOptions extends {}, TRenderer extend
       ...renderUtils
     }
   }
+
+  // If the function name does not get used before it is returned,
+  // it seems to vanish in nodejs and does not appear in stack traces.
+  // This dummy usage works around that.
+  const _name = renderHook.name // eslint-disable-line @typescript-eslint/no-unused-vars
+
+  return renderHook
 }
 
 export { createRenderHook, cleanup, addCleanup, removeCleanup }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -77,9 +77,10 @@ function createRenderHook<TProps, TResult, TOptions extends {}, TRenderer extend
   }
 
   // If the function name does not get used before it is returned,
-  // it seems to vanish in nodejs and does not appear in stack traces.
+  // it's name is removed by babel-plugin-minify-dead-code-elimination.
   // This dummy usage works around that.
-  const _name = renderHook.name // eslint-disable-line @typescript-eslint/no-unused-vars
+  renderHook.name // eslint-disable-line @typescript-eslint/no-unused-expressions
+
 
   return renderHook
 }

--- a/src/dom/pure.ts
+++ b/src/dom/pure.ts
@@ -13,18 +13,18 @@ function createDomRenderer<TProps, TResult>(
 ) {
   const container = document.createElement('div')
 
-  const testHook = createTestHarness(rendererProps, wrapper)
+  const testHarness = createTestHarness(rendererProps, wrapper)
 
   return {
     render(props?: TProps) {
       document.body.appendChild(container)
       act(() => {
-        ReactDOM.render(testHook(props), container)
+        ReactDOM.render(testHarness(props), container)
       })
     },
     rerender(props?: TProps) {
       act(() => {
-        ReactDOM.render(testHook(props), container)
+        ReactDOM.render(testHarness(props), container)
       })
     },
     unmount() {

--- a/src/helpers/createTestHarness.tsx
+++ b/src/helpers/createTestHarness.tsx
@@ -41,9 +41,9 @@ function createTestHarness<TProps, TResult>(
   }
 
   // If the function name does not get used before it is returned,
-  // it seems to vanish in nodejs and does not appear in stack traces.
+  // it's name is removed by babel-plugin-minify-dead-code-elimination.
   // This dummy usage works around that.
-  const _name = testHarness.name // eslint-disable-line @typescript-eslint/no-unused-vars
+  testHarness.name // eslint-disable-line @typescript-eslint/no-unused-expressions
 
   return testHarness
 }

--- a/src/helpers/createTestHarness.tsx
+++ b/src/helpers/createTestHarness.tsx
@@ -24,11 +24,11 @@ function TestComponent<TProps, TResult>({
   return null
 }
 
-export const createTestHarness = <TProps, TResult>(
+function createTestHarness<TProps, TResult>(
   rendererProps: RendererProps<TProps, TResult>,
   Wrapper?: WrapperComponent<TProps>,
   suspense: boolean = true
-) => {
+) {
   return (props?: TProps) => {
     let component = <TestComponent hookProps={props} {...rendererProps} />
     if (Wrapper) {
@@ -40,3 +40,5 @@ export const createTestHarness = <TProps, TResult>(
     return component
   }
 }
+
+export { createTestHarness }

--- a/src/helpers/createTestHarness.tsx
+++ b/src/helpers/createTestHarness.tsx
@@ -29,7 +29,7 @@ function createTestHarness<TProps, TResult>(
   Wrapper?: WrapperComponent<TProps>,
   suspense: boolean = true
 ) {
-  return function testHarness(props?: TProps) {
+  const testHarness = (props?: TProps) => {
     let component = <TestComponent hookProps={props} {...rendererProps} />
     if (Wrapper) {
       component = <Wrapper {...(props as TProps)}>{component}</Wrapper>
@@ -39,6 +39,13 @@ function createTestHarness<TProps, TResult>(
     }
     return component
   }
+
+  // If the function name does not get used before it is returned,
+  // it seems to vanish in nodejs and does not appear in stack traces.
+  // This dummy usage works around that.
+  const _name = testHarness.name // eslint-disable-line @typescript-eslint/no-unused-vars
+
+  return testHarness
 }
 
 export { createTestHarness }

--- a/src/helpers/createTestHarness.tsx
+++ b/src/helpers/createTestHarness.tsx
@@ -29,7 +29,7 @@ function createTestHarness<TProps, TResult>(
   Wrapper?: WrapperComponent<TProps>,
   suspense: boolean = true
 ) {
-  return (props?: TProps) => {
+  return function testHarness(props?: TProps) {
     let component = <TestComponent hookProps={props} {...rendererProps} />
     if (Wrapper) {
       component = <Wrapper {...(props as TProps)}>{component}</Wrapper>

--- a/src/helpers/promises.ts
+++ b/src/helpers/promises.ts
@@ -1,9 +1,11 @@
-const resolveAfter = (ms: number) =>
-  new Promise((resolve) => {
+function resolveAfter(ms: number) {
+  return new Promise((resolve) => {
     setTimeout(resolve, ms)
   })
+}
 
-const isPromise = <T>(value: unknown): boolean =>
-  typeof (value as PromiseLike<T>).then === 'function'
+function isPromise<T>(value: unknown): boolean {
+  return typeof (value as PromiseLike<T>).then === 'function'
+}
 
 export { isPromise, resolveAfter }

--- a/src/native/pure.ts
+++ b/src/native/pure.ts
@@ -7,22 +7,22 @@ import { createRenderHook, cleanup, addCleanup, removeCleanup } from '../core'
 import { createTestHarness } from '../helpers/createTestHarness'
 
 function createNativeRenderer<TProps, TResult>(
-  testHookProps: RendererProps<TProps, TResult>,
+  rendererProps: RendererProps<TProps, TResult>,
   { wrapper }: RendererOptions<TProps>
 ) {
   let container: ReactTestRenderer
 
-  const testHook = createTestHarness(testHookProps, wrapper)
+  const testHarness = createTestHarness(rendererProps, wrapper)
 
   return {
     render(props?: TProps) {
       act(() => {
-        container = create(testHook(props))
+        container = create(testHarness(props))
       })
     },
     rerender(props?: TProps) {
       act(() => {
-        container.update(testHook(props))
+        container.update(testHarness(props))
       })
     },
     unmount() {

--- a/src/server/pure.ts
+++ b/src/server/pure.ts
@@ -14,7 +14,7 @@ function createServerRenderer<TProps, TResult>(
 ) {
   const container = document.createElement('div')
 
-  const testHook = createTestHarness(rendererProps, wrapper, false)
+  const testHarness = createTestHarness(rendererProps, wrapper, false)
 
   let renderProps: TProps | undefined
   let hydrated = false
@@ -23,7 +23,7 @@ function createServerRenderer<TProps, TResult>(
     render(props?: TProps) {
       renderProps = props
       act(() => {
-        const serverOutput = ReactDOMServer.renderToString(testHook(props))
+        const serverOutput = ReactDOMServer.renderToString(testHarness(props))
         container.innerHTML = serverOutput
       })
     },
@@ -33,7 +33,7 @@ function createServerRenderer<TProps, TResult>(
       } else {
         document.body.appendChild(container)
         act(() => {
-          ReactDOM.hydrate(testHook(renderProps), container)
+          ReactDOM.hydrate(testHarness(renderProps), container)
         })
         hydrated = true
       }
@@ -43,7 +43,7 @@ function createServerRenderer<TProps, TResult>(
         throw new Error('You must hydrate the component before you can rerender')
       }
       act(() => {
-        ReactDOM.render(testHook(props), container)
+        ReactDOM.render(testHarness(props), container)
       })
     },
     unmount() {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

More consistency across the codebase.

**Why**:

It started with me wanting to have a named function as the result of `createRenderHook` rather than the anonymous arrow function it is returning now to improve stack traces when debugging, but the more I looked the more I noticed we had a real mix of regular functions and arrow functions through the codebase, even within the same file.  This led me down a rabbit hole of a few other things that weren't quite right, names default exports and a few variable names.

**How**:

<!-- How were these changes implemented? -->

For functions I followed the rules:

1. regular function at the top level
2. arrow function for inner functions
3. arrow functions for anonymous functions

We only had a single `default export` left in the codebase.  There has been a growing movement in the community away from them and to just use named exports instead.  It's become my personal preference for all exports over the last few months.

Finally, `testHookProps` was previously renamed to `rendererProps` in all but one of the renderers (`native`), so I have changed that on now as well.  Also, I renamed `testHook` to `testHarness` in all renderers as it is the result of the `createTestHarness` helper.

**Checklist**:

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

There is also a lot of inconsistency in the types with respect to `interface` vs `type`, but I'll do another PR for that as I want change something else and #527 moves one of the types I need to change so I'll wait for that one to be merged also.