### PR TITLE
Refactor async utils

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -201,7 +201,7 @@ removed, the provided callback will no longer execute as part of running
 ### `waitForNextUpdate`
 
 ```ts
-function waitForNextUpdate(options?: { timeout?: number }): Promise<void>
+function waitForNextUpdate(options?: { timeout?: number | false }): Promise<void>
 ```
 
 Returns a `Promise` that resolves the next time the hook renders, commonly when state is updated as
@@ -209,7 +209,9 @@ the result of an asynchronous update.
 
 #### `timeout`
 
-The maximum amount of time in milliseconds (ms) to wait. By default, no timeout is applied.
+_Default: 1000_
+
+The maximum amount of time in milliseconds (ms) to wait.
 
 ### `waitFor`
 
@@ -217,9 +219,8 @@ The maximum amount of time in milliseconds (ms) to wait. By default, no timeout 
 function waitFor(
   callback: () => boolean | void,
   options?: {
-    interval?: number
-    timeout?: number
-    suppressErrors?: boolean
+    interval?: number | false
+    timeout?: number | false
   }
 ): Promise<void>
 ```
@@ -230,19 +231,16 @@ in the callback to perform assertion or to test values.
 
 #### `interval`
 
+_Default: 50_
+
 The amount of time in milliseconds (ms) to wait between checks of the callback if no renders occur.
-Interval checking is disabled if `interval` is not provided in the options or provided as a `falsy`
-value. By default, it is disabled.
+Interval checking is disabled if `interval` is not provided as a `falsy`.
 
 #### `timeout`
 
-The maximum amount of time in milliseconds (ms) to wait. By default, no timeout is applied.
+_Default: 1000_
 
-#### `suppressErrors`
-
-If this option is set to `true`, any errors that occur while waiting are treated as a failed check.
-If this option is set to `false`, any errors that occur while waiting cause the promise to be
-rejected. By default, errors are suppressed for this utility.
+The maximum amount of time in milliseconds (ms) to wait.
 
 ### `waitForValueToChange`
 
@@ -250,9 +248,8 @@ rejected. By default, errors are suppressed for this utility.
 function waitForValueToChange(
   selector: () => any,
   options?: {
-    interval?: number
-    timeout?: number
-    suppressErrors?: boolean
+    interval?: number | false
+    timeout?: number | false
   }
 ): Promise<void>
 ```
@@ -263,16 +260,13 @@ for comparison.
 
 #### `interval`
 
+_Default: 50_
+
 The amount of time in milliseconds (ms) to wait between checks of the callback if no renders occur.
-Interval checking is disabled if `interval` is not provided in the options or provided as a `falsy`
-value. By default, it is disabled.
+Interval checking is disabled if `interval` is not provided as a `falsy`.
 
 #### `timeout`
 
-The maximum amount of time in milliseconds (ms) to wait. By default, no timeout is applied.
+_Default: 1000_
 
-#### `suppressErrors`
-
-If this option is set to `true`, any errors that occur while waiting are treated as a failed check.
-If this option is set to `false`, any errors that occur while waiting cause the promise to be
-rejected. By default, errors are not suppressed for this utility.
+The maximum amount of time in milliseconds (ms) to wait.

--- a/package.json
+++ b/package.json
@@ -70,9 +70,6 @@
     "react-test-renderer": ">=16.9.0"
   },
   "peerDependenciesMeta": {
-    "react": {
-      "optional": true
-    },
     "react-dom": {
       "optional": true
     },

--- a/src/core/asyncUtils.ts
+++ b/src/core/asyncUtils.ts
@@ -1,88 +1,107 @@
-import { Act, WaitOptions, AsyncUtils } from '../types'
+import {
+  Act,
+  WaitOptions,
+  WaitForOptions,
+  WaitForValueToChangeOptions,
+  WaitForNextUpdateOptions,
+  AsyncUtils
+} from '../types'
 
 import { resolveAfter } from '../helpers/promises'
 import { TimeoutError } from '../helpers/error'
 
+const DEFAULT_INTERVAL = 50
+const DEFAULT_TIMEOUT = 1000
+
 function asyncUtils(act: Act, addResolver: (callback: () => void) => void): AsyncUtils {
-  let nextUpdatePromise: Promise<void> | null = null
-
-  const waitForNextUpdate = async ({ timeout }: Pick<WaitOptions, 'timeout'> = {}) => {
-    if (nextUpdatePromise) {
-      await nextUpdatePromise
-    } else {
-      nextUpdatePromise = new Promise((resolve, reject) => {
-        let timeoutId: ReturnType<typeof setTimeout>
-        if (timeout && timeout > 0) {
-          timeoutId = setTimeout(
-            () => reject(new TimeoutError(waitForNextUpdate, timeout)),
-            timeout
-          )
-        }
-        addResolver(() => {
-          clearTimeout(timeoutId)
-          nextUpdatePromise = null
-          resolve()
-        })
-      })
-      await act(() => nextUpdatePromise as Promise<void>)
-    }
-  }
-
-  const waitFor = async (
+  const wait = async (
     callback: () => boolean | void,
-    { interval, timeout, suppressErrors = true }: WaitOptions = {}
+    { interval = DEFAULT_INTERVAL, timeout = DEFAULT_TIMEOUT }: WaitOptions = {}
   ) => {
     const checkResult = () => {
-      try {
-        const callbackResult = callback()
-        return callbackResult ?? callbackResult === undefined
-      } catch (error: unknown) {
-        if (!suppressErrors) {
-          throw error
-        }
-        return undefined
-      }
+      const callbackResult = callback()
+      return callbackResult ?? callbackResult === undefined
     }
 
     const waitForResult = async () => {
-      const initialTimeout = timeout
       while (true) {
-        const startTime = Date.now()
-        try {
-          const nextCheck = interval
-            ? Promise.race([waitForNextUpdate({ timeout }), resolveAfter(interval)])
-            : waitForNextUpdate({ timeout })
+        await Promise.race(
+          [
+            new Promise<void>((resolve) => addResolver(resolve)),
+            interval && resolveAfter(interval)
+          ].filter(Boolean)
+        )
 
-          await nextCheck
-
-          if (checkResult()) {
-            return
-          }
-        } catch (error: unknown) {
-          if (error instanceof TimeoutError && initialTimeout) {
-            throw new TimeoutError(waitFor, initialTimeout)
-          }
-          throw error
+        if (checkResult()) {
+          return
         }
-        if (timeout) timeout -= Date.now() - startTime
       }
     }
 
     if (!checkResult()) {
-      await waitForResult()
+      if (timeout) {
+        const timeoutPromise = new Promise<void>((resolve, reject) => {
+          if (timeout) {
+            setTimeout(() => reject(new TimeoutError(wait, timeout)), timeout)
+          } else {
+            resolve()
+          }
+        })
+
+        await act(() => Promise.race([waitForResult(), timeoutPromise]))
+      } else {
+        await act(waitForResult)
+      }
     }
   }
 
-  const waitForValueToChange = async (selector: () => unknown, options: WaitOptions = {}) => {
+  const waitFor = async (callback: () => boolean | void, options: WaitForOptions = {}) => {
+    const safeCallback = () => {
+      try {
+        return callback()
+      } catch (error: unknown) {
+        return false
+      }
+    }
+    try {
+      await wait(safeCallback, options)
+    } catch (error: unknown) {
+      if (error instanceof TimeoutError) {
+        throw new TimeoutError(waitFor, error.timeout)
+      }
+      throw error
+    }
+  }
+
+  const waitForValueToChange = async (
+    selector: () => unknown,
+    options: WaitForValueToChangeOptions = {}
+  ) => {
     const initialValue = selector()
     try {
-      await waitFor(() => selector() !== initialValue, {
-        suppressErrors: false,
+      await wait(() => selector() !== initialValue, options)
+    } catch (error: unknown) {
+      if (error instanceof TimeoutError) {
+        throw new TimeoutError(waitForValueToChange, error.timeout)
+      }
+      throw error
+    }
+  }
+
+  const waitForNextUpdate = async (options: WaitForNextUpdateOptions = {}) => {
+    let updated = false
+    addResolver(() => {
+      updated = true
+    })
+
+    try {
+      await wait(() => updated, {
+        interval: false,
         ...options
       })
     } catch (error: unknown) {
-      if (error instanceof TimeoutError && options.timeout) {
-        throw new TimeoutError(waitForValueToChange, options.timeout)
+      if (error instanceof TimeoutError) {
+        throw new TimeoutError(waitForNextUpdate, error.timeout)
       }
       throw error
     }
@@ -90,8 +109,8 @@ function asyncUtils(act: Act, addResolver: (callback: () => void) => void): Asyn
 
   return {
     waitFor,
-    waitForNextUpdate,
-    waitForValueToChange
+    waitForValueToChange,
+    waitForNextUpdate
   }
 }
 

--- a/src/core/asyncUtils.ts
+++ b/src/core/asyncUtils.ts
@@ -7,7 +7,7 @@ import {
   AsyncUtils
 } from '../types'
 
-import { resolveAfter } from '../helpers/promises'
+import { resolveAfter, callAfter } from '../helpers/promises'
 import { TimeoutError } from '../helpers/error'
 
 const DEFAULT_INTERVAL = 50
@@ -40,13 +40,9 @@ function asyncUtils(act: Act, addResolver: (callback: () => void) => void): Asyn
 
     if (!checkResult()) {
       if (timeout) {
-        const timeoutPromise = new Promise<void>((resolve, reject) => {
-          if (timeout) {
-            setTimeout(() => reject(new TimeoutError(wait, timeout)), timeout)
-          } else {
-            resolve()
-          }
-        })
+        const timeoutPromise = callAfter(() => {
+          throw new TimeoutError(wait, timeout)
+        }, timeout)
 
         await act(() => Promise.race([waitForResult(), timeoutPromise]))
       } else {

--- a/src/dom/__tests__/asyncHook.test.ts
+++ b/src/dom/__tests__/asyncHook.test.ts
@@ -2,28 +2,29 @@ import { useState, useRef, useEffect } from 'react'
 import { renderHook } from '..'
 
 describe('async hook tests', () => {
-  const useSequence = (...values: string[]) => {
+  const useSequence = (values: string[], intervalMs = 50) => {
     const [first, ...otherValues] = values
-    const [value, setValue] = useState(first)
+    const [value, setValue] = useState(() => first)
     const index = useRef(0)
 
     useEffect(() => {
       const interval = setInterval(() => {
         setValue(otherValues[index.current++])
-        if (index.current === otherValues.length) {
+        if (index.current >= otherValues.length) {
           clearInterval(interval)
         }
-      }, 50)
+      }, intervalMs)
       return () => {
         clearInterval(interval)
       }
-    }, [otherValues])
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, otherValues)
 
     return value
   }
 
   test('should wait for next update', async () => {
-    const { result, waitForNextUpdate } = renderHook(() => useSequence('first', 'second'))
+    const { result, waitForNextUpdate } = renderHook(() => useSequence(['first', 'second']))
 
     expect(result.current).toBe('first')
 
@@ -33,7 +34,9 @@ describe('async hook tests', () => {
   })
 
   test('should wait for multiple updates', async () => {
-    const { result, waitForNextUpdate } = renderHook(() => useSequence('first', 'second', 'third'))
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useSequence(['first', 'second', 'third'])
+    )
 
     expect(result.current).toBe('first')
 
@@ -46,18 +49,8 @@ describe('async hook tests', () => {
     expect(result.current).toBe('third')
   })
 
-  test('should resolve all when updating', async () => {
-    const { result, waitForNextUpdate } = renderHook(() => useSequence('first', 'second'))
-
-    expect(result.current).toBe('first')
-
-    await Promise.all([waitForNextUpdate(), waitForNextUpdate(), waitForNextUpdate()])
-
-    expect(result.current).toBe('second')
-  })
-
   test('should reject if timeout exceeded when waiting for next update', async () => {
-    const { result, waitForNextUpdate } = renderHook(() => useSequence('first', 'second'))
+    const { result, waitForNextUpdate } = renderHook(() => useSequence(['first', 'second']))
 
     expect(result.current).toBe('first')
 
@@ -66,8 +59,18 @@ describe('async hook tests', () => {
     )
   })
 
+  test('should not reject when waiting for next update if timeout has been disabled', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useSequence(['first', 'second'], 1100))
+
+    expect(result.current).toBe('first')
+
+    await waitForNextUpdate({ timeout: false })
+
+    expect(result.current).toBe('second')
+  })
+
   test('should wait for expectation to pass', async () => {
-    const { result, waitFor } = renderHook(() => useSequence('first', 'second', 'third'))
+    const { result, waitFor } = renderHook(() => useSequence(['first', 'second', 'third']))
 
     expect(result.current).toBe('first')
 
@@ -90,19 +93,16 @@ describe('async hook tests', () => {
     }, 200)
 
     let complete = false
-    await waitFor(
-      () => {
-        expect(actual).toBe(expected)
-        complete = true
-      },
-      { interval: 100 }
-    )
+    await waitFor(() => {
+      expect(actual).toBe(expected)
+      complete = true
+    })
 
     expect(complete).toBe(true)
   })
 
   test('should not hang if expectation is already passing', async () => {
-    const { result, waitFor } = renderHook(() => useSequence('first', 'second'))
+    const { result, waitFor } = renderHook(() => useSequence(['first', 'second']))
 
     expect(result.current).toBe('first')
 
@@ -114,45 +114,8 @@ describe('async hook tests', () => {
     expect(complete).toBe(true)
   })
 
-  test('should reject if callback throws error', async () => {
-    const { result, waitFor } = renderHook(() => useSequence('first', 'second', 'third'))
-
-    expect(result.current).toBe('first')
-
-    await expect(
-      waitFor(
-        () => {
-          if (result.current === 'second') {
-            throw new Error('Something Unexpected')
-          }
-          return result.current === 'third'
-        },
-        {
-          suppressErrors: false
-        }
-      )
-    ).rejects.toThrow(Error('Something Unexpected'))
-  })
-
-  test('should reject if callback immediately throws error', async () => {
-    const { result, waitFor } = renderHook(() => useSequence('first', 'second', 'third'))
-
-    expect(result.current).toBe('first')
-
-    await expect(
-      waitFor(
-        () => {
-          throw new Error('Something Unexpected')
-        },
-        {
-          suppressErrors: false
-        }
-      )
-    ).rejects.toThrow(Error('Something Unexpected'))
-  })
-
   test('should wait for truthy value', async () => {
-    const { result, waitFor } = renderHook(() => useSequence('first', 'second', 'third'))
+    const { result, waitFor } = renderHook(() => useSequence(['first', 'second', 'third']))
 
     expect(result.current).toBe('first')
 
@@ -171,13 +134,13 @@ describe('async hook tests', () => {
       actual = expected
     }, 200)
 
-    await waitFor(() => actual === 1, { interval: 100 })
+    await waitFor(() => actual === 1)
 
     expect(actual).toBe(expected)
   })
 
   test('should reject if timeout exceeded when waiting for expectation to pass', async () => {
-    const { result, waitFor } = renderHook(() => useSequence('first', 'second', 'third'))
+    const { result, waitFor } = renderHook(() => useSequence(['first', 'second', 'third']))
 
     expect(result.current).toBe('first')
 
@@ -191,9 +154,42 @@ describe('async hook tests', () => {
     ).rejects.toThrow(Error('Timed out in waitFor after 75ms.'))
   })
 
+  test('should not reject when waiting for expectation to pass if timeout has been disabled', async () => {
+    const { result, waitFor } = renderHook(() => useSequence(['first', 'second', 'third'], 550))
+
+    expect(result.current).toBe('first')
+
+    await waitFor(
+      () => {
+        expect(result.current).toBe('third')
+      },
+      { timeout: false }
+    )
+
+    expect(result.current).toBe('third')
+  })
+
+  test('should check on interval when waiting for expectation to pass', async () => {
+    const { result, waitFor } = renderHook(() => useSequence(['first', 'second', 'third']))
+
+    let checks = 0
+
+    try {
+      await waitFor(
+        () => {
+          checks++
+          return result.current === 'third'
+        },
+        { interval: 100 }
+      )
+    } catch {}
+
+    expect(checks).toBe(3)
+  })
+
   test('should wait for value to change', async () => {
     const { result, waitForValueToChange } = renderHook(() =>
-      useSequence('first', 'second', 'third')
+      useSequence(['first', 'second', 'third'])
     )
 
     expect(result.current).toBe('first')
@@ -213,14 +209,14 @@ describe('async hook tests', () => {
       actual = expected
     }, 200)
 
-    await waitForValueToChange(() => actual, { interval: 100 })
+    await waitForValueToChange(() => actual)
 
     expect(actual).toBe(expected)
   })
 
   test('should reject if timeout exceeded when waiting for value to change', async () => {
     const { result, waitForValueToChange } = renderHook(() =>
-      useSequence('first', 'second', 'third')
+      useSequence(['first', 'second', 'third'])
     )
 
     expect(result.current).toBe('first')
@@ -232,8 +228,22 @@ describe('async hook tests', () => {
     ).rejects.toThrow(Error('Timed out in waitForValueToChange after 75ms.'))
   })
 
+  test('should not reject when waiting for value to change if timeout is disabled', async () => {
+    const { result, waitForValueToChange } = renderHook(() =>
+      useSequence(['first', 'second', 'third'], 550)
+    )
+
+    expect(result.current).toBe('first')
+
+    await waitForValueToChange(() => result.current === 'third', {
+      timeout: false
+    })
+
+    expect(result.current).toBe('third')
+  })
+
   test('should reject if selector throws error', async () => {
-    const { result, waitForValueToChange } = renderHook(() => useSequence('first', 'second'))
+    const { result, waitForValueToChange } = renderHook(() => useSequence(['first', 'second']))
 
     expect(result.current).toBe('first')
 
@@ -245,25 +255,5 @@ describe('async hook tests', () => {
         return result.current
       })
     ).rejects.toThrow(Error('Something Unexpected'))
-  })
-
-  test('should not reject if selector throws error and suppress errors option is enabled', async () => {
-    const { result, waitForValueToChange } = renderHook(() =>
-      useSequence('first', 'second', 'third')
-    )
-
-    expect(result.current).toBe('first')
-
-    await waitForValueToChange(
-      () => {
-        if (result.current === 'second') {
-          throw new Error('Something Unexpected')
-        }
-        return result.current === 'third'
-      },
-      { suppressErrors: true }
-    )
-
-    expect(result.current).toBe('third')
   })
 })

--- a/src/helpers/error.ts
+++ b/src/helpers/error.ts
@@ -1,6 +1,9 @@
 class TimeoutError extends Error {
+  timeout: number
+
   constructor(util: Function, timeout: number) {
     super(`Timed out in ${util.name} after ${timeout}ms.`)
+    this.timeout = timeout
   }
 }
 

--- a/src/helpers/error.ts
+++ b/src/helpers/error.ts
@@ -1,9 +1,6 @@
 class TimeoutError extends Error {
-  timeout: number
-
   constructor(util: Function, timeout: number) {
     super(`Timed out in ${util.name} after ${timeout}ms.`)
-    this.timeout = timeout
   }
 }
 

--- a/src/helpers/promises.ts
+++ b/src/helpers/promises.ts
@@ -1,7 +1,10 @@
 function resolveAfter(ms: number) {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms)
-  })
+  return new Promise<void>((resolve) => setTimeout(resolve, ms))
+}
+
+export async function callAfter(callback: () => void, ms: number) {
+  await resolveAfter(ms)
+  callback()
 }
 
 function isPromise<T>(value: unknown): boolean {

--- a/src/native/__tests__/asyncHook.test.ts
+++ b/src/native/__tests__/asyncHook.test.ts
@@ -2,28 +2,29 @@ import { useState, useRef, useEffect } from 'react'
 import { renderHook } from '..'
 
 describe('async hook tests', () => {
-  const useSequence = (...values: string[]) => {
+  const useSequence = (values: string[], intervalMs = 50) => {
     const [first, ...otherValues] = values
-    const [value, setValue] = useState(first)
+    const [value, setValue] = useState(() => first)
     const index = useRef(0)
 
     useEffect(() => {
       const interval = setInterval(() => {
         setValue(otherValues[index.current++])
-        if (index.current === otherValues.length) {
+        if (index.current >= otherValues.length) {
           clearInterval(interval)
         }
-      }, 50)
+      }, intervalMs)
       return () => {
         clearInterval(interval)
       }
-    }, [otherValues])
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, otherValues)
 
     return value
   }
 
   test('should wait for next update', async () => {
-    const { result, waitForNextUpdate } = renderHook(() => useSequence('first', 'second'))
+    const { result, waitForNextUpdate } = renderHook(() => useSequence(['first', 'second']))
 
     expect(result.current).toBe('first')
 
@@ -33,7 +34,9 @@ describe('async hook tests', () => {
   })
 
   test('should wait for multiple updates', async () => {
-    const { result, waitForNextUpdate } = renderHook(() => useSequence('first', 'second', 'third'))
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useSequence(['first', 'second', 'third'])
+    )
 
     expect(result.current).toBe('first')
 
@@ -46,18 +49,8 @@ describe('async hook tests', () => {
     expect(result.current).toBe('third')
   })
 
-  test('should resolve all when updating', async () => {
-    const { result, waitForNextUpdate } = renderHook(() => useSequence('first', 'second'))
-
-    expect(result.current).toBe('first')
-
-    await Promise.all([waitForNextUpdate(), waitForNextUpdate(), waitForNextUpdate()])
-
-    expect(result.current).toBe('second')
-  })
-
   test('should reject if timeout exceeded when waiting for next update', async () => {
-    const { result, waitForNextUpdate } = renderHook(() => useSequence('first', 'second'))
+    const { result, waitForNextUpdate } = renderHook(() => useSequence(['first', 'second']))
 
     expect(result.current).toBe('first')
 
@@ -66,8 +59,18 @@ describe('async hook tests', () => {
     )
   })
 
+  test('should not reject when waiting for next update if timeout has been disabled', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useSequence(['first', 'second'], 1100))
+
+    expect(result.current).toBe('first')
+
+    await waitForNextUpdate({ timeout: false })
+
+    expect(result.current).toBe('second')
+  })
+
   test('should wait for expectation to pass', async () => {
-    const { result, waitFor } = renderHook(() => useSequence('first', 'second', 'third'))
+    const { result, waitFor } = renderHook(() => useSequence(['first', 'second', 'third']))
 
     expect(result.current).toBe('first')
 
@@ -90,19 +93,16 @@ describe('async hook tests', () => {
     }, 200)
 
     let complete = false
-    await waitFor(
-      () => {
-        expect(actual).toBe(expected)
-        complete = true
-      },
-      { interval: 100 }
-    )
+    await waitFor(() => {
+      expect(actual).toBe(expected)
+      complete = true
+    })
 
     expect(complete).toBe(true)
   })
 
   test('should not hang if expectation is already passing', async () => {
-    const { result, waitFor } = renderHook(() => useSequence('first', 'second'))
+    const { result, waitFor } = renderHook(() => useSequence(['first', 'second']))
 
     expect(result.current).toBe('first')
 
@@ -114,45 +114,8 @@ describe('async hook tests', () => {
     expect(complete).toBe(true)
   })
 
-  test('should reject if callback throws error', async () => {
-    const { result, waitFor } = renderHook(() => useSequence('first', 'second', 'third'))
-
-    expect(result.current).toBe('first')
-
-    await expect(
-      waitFor(
-        () => {
-          if (result.current === 'second') {
-            throw new Error('Something Unexpected')
-          }
-          return result.current === 'third'
-        },
-        {
-          suppressErrors: false
-        }
-      )
-    ).rejects.toThrow(Error('Something Unexpected'))
-  })
-
-  test('should reject if callback immediately throws error', async () => {
-    const { result, waitFor } = renderHook(() => useSequence('first', 'second', 'third'))
-
-    expect(result.current).toBe('first')
-
-    await expect(
-      waitFor(
-        () => {
-          throw new Error('Something Unexpected')
-        },
-        {
-          suppressErrors: false
-        }
-      )
-    ).rejects.toThrow(Error('Something Unexpected'))
-  })
-
   test('should wait for truthy value', async () => {
-    const { result, waitFor } = renderHook(() => useSequence('first', 'second', 'third'))
+    const { result, waitFor } = renderHook(() => useSequence(['first', 'second', 'third']))
 
     expect(result.current).toBe('first')
 
@@ -171,13 +134,13 @@ describe('async hook tests', () => {
       actual = expected
     }, 200)
 
-    await waitFor(() => actual === 1, { interval: 100 })
+    await waitFor(() => actual === 1)
 
     expect(actual).toBe(expected)
   })
 
   test('should reject if timeout exceeded when waiting for expectation to pass', async () => {
-    const { result, waitFor } = renderHook(() => useSequence('first', 'second', 'third'))
+    const { result, waitFor } = renderHook(() => useSequence(['first', 'second', 'third']))
 
     expect(result.current).toBe('first')
 
@@ -191,9 +154,42 @@ describe('async hook tests', () => {
     ).rejects.toThrow(Error('Timed out in waitFor after 75ms.'))
   })
 
+  test('should not reject when waiting for expectation to pass if timeout has been disabled', async () => {
+    const { result, waitFor } = renderHook(() => useSequence(['first', 'second', 'third'], 550))
+
+    expect(result.current).toBe('first')
+
+    await waitFor(
+      () => {
+        expect(result.current).toBe('third')
+      },
+      { timeout: false }
+    )
+
+    expect(result.current).toBe('third')
+  })
+
+  test('should check on interval when waiting for expectation to pass', async () => {
+    const { result, waitFor } = renderHook(() => useSequence(['first', 'second', 'third']))
+
+    let checks = 0
+
+    try {
+      await waitFor(
+        () => {
+          checks++
+          return result.current === 'third'
+        },
+        { interval: 100 }
+      )
+    } catch {}
+
+    expect(checks).toBe(3)
+  })
+
   test('should wait for value to change', async () => {
     const { result, waitForValueToChange } = renderHook(() =>
-      useSequence('first', 'second', 'third')
+      useSequence(['first', 'second', 'third'])
     )
 
     expect(result.current).toBe('first')
@@ -213,14 +209,14 @@ describe('async hook tests', () => {
       actual = expected
     }, 200)
 
-    await waitForValueToChange(() => actual, { interval: 100 })
+    await waitForValueToChange(() => actual)
 
     expect(actual).toBe(expected)
   })
 
   test('should reject if timeout exceeded when waiting for value to change', async () => {
     const { result, waitForValueToChange } = renderHook(() =>
-      useSequence('first', 'second', 'third')
+      useSequence(['first', 'second', 'third'])
     )
 
     expect(result.current).toBe('first')
@@ -232,8 +228,22 @@ describe('async hook tests', () => {
     ).rejects.toThrow(Error('Timed out in waitForValueToChange after 75ms.'))
   })
 
+  test('should not reject when waiting for value to change if timeout is disabled', async () => {
+    const { result, waitForValueToChange } = renderHook(() =>
+      useSequence(['first', 'second', 'third'], 550)
+    )
+
+    expect(result.current).toBe('first')
+
+    await waitForValueToChange(() => result.current === 'third', {
+      timeout: false
+    })
+
+    expect(result.current).toBe('third')
+  })
+
   test('should reject if selector throws error', async () => {
-    const { result, waitForValueToChange } = renderHook(() => useSequence('first', 'second'))
+    const { result, waitForValueToChange } = renderHook(() => useSequence(['first', 'second']))
 
     expect(result.current).toBe('first')
 
@@ -245,25 +255,5 @@ describe('async hook tests', () => {
         return result.current
       })
     ).rejects.toThrow(Error('Something Unexpected'))
-  })
-
-  test('should not reject if selector throws error and suppress errors option is enabled', async () => {
-    const { result, waitForValueToChange } = renderHook(() =>
-      useSequence('first', 'second', 'third')
-    )
-
-    expect(result.current).toBe('first')
-
-    await waitForValueToChange(
-      () => {
-        if (result.current === 'second') {
-          throw new Error('Something Unexpected')
-        }
-        return result.current === 'third'
-      },
-      { suppressErrors: true }
-    )
-
-    expect(result.current).toBe('third')
   })
 })

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,16 +28,26 @@ export type ResultContainer<TValue> = {
   result: RenderResult<TValue>
 }
 
-export interface WaitOptions {
-  interval?: number
-  timeout?: number
-  suppressErrors?: boolean
+export type WaitOptions = {
+  interval?: number | false
+  timeout?: number | false
 }
 
+export type WaitForOptions = WaitOptions
+export type WaitForValueToChangeOptions = WaitOptions
+export type WaitForNextUpdateOptions = Pick<WaitOptions, 'timeout'>
+
+export type WaitFor = (callback: () => boolean | void, options?: WaitForOptions) => Promise<void>
+export type WaitForValueToChange = (
+  selector: () => unknown,
+  options?: WaitForValueToChangeOptions
+) => Promise<void>
+export type WaitForNextUpdate = (options?: WaitForNextUpdateOptions) => Promise<void>
+
 export type AsyncUtils = {
-  waitFor: (callback: () => boolean | void, opts?: WaitOptions) => Promise<void>
-  waitForNextUpdate: (opts?: Pick<WaitOptions, 'timeout'>) => Promise<void>
-  waitForValueToChange: (selector: () => unknown, options?: WaitOptions) => Promise<void>
+  waitFor: WaitFor
+  waitForValueToChange: WaitForValueToChange
+  waitForNextUpdate: WaitForNextUpdate
 }
 
 export type RenderHookResult<


### PR DESCRIPTION
**What**:

Completely refactor the async utils to be more correct and have more sensible defaults.

**Why**:

This is something I've wanted to do for a while now.  `timeout` and `interval` were both added after the async utils were originally developed, so fo backwards compatibility, we left them as defaulting to off. The catalyst for this change was to add in defaults and require people to opt out of the functionality if they wanted to.

I thought it was going to be straight forward to add the default, but when I did I found lots (most) of our async tests began failing.  I discovered that we actually had a few bugs in the implementation, particularly around overlapping `act` calls and seemingly a leaking promise that wasn't being `awaited` in some circumstances.  So I decided to build it from scratch and see how that went.

**How**:

The main change of the refactor is restructuring thee order of the utils.  Previously, `waitForNextUpdate` was the base utility that all others were build off.  `waitFor` piggy backed off of the render updates and added a layer of interval checking over the top. `waitForValueToChange` was a thing wrapper around `waitFor` to turn a selector into a callback.  In the new version, there is a base `wait` util that is not exported, but provides the render updates, interval checking and timeouts, but with minimal logic around what to do other than call the callback.  All of the other utilities now provide a thin wrapper around `wait` to add their pieces of nuanced logic. 

Because the default behaviour of `waitFor` was to suppress any errors (so `expect` could be used in the callback), there was a really clunky option called `suppressErrors` that `waitForValueToChange` would override to throw the errors if a bad selector was used.  It was annoying to document, confusing when to set it and I don't believe anyone should ever want to use anything but the defaults.  A consequence of this refactor was I was able to remove `suppressErrors` without losing the functionality.

The other change is that you can no longer `await` multiple utilities at the same time without getting a warning about having overlapping `act` calls.  I'm not sure why I felt it was so important to support this use case before I can't see any reason why anyone would need to do this.  removing it simplified the internal `act` logic and  the overall complexity of the base `wait` utility.

**Checklist**:

- [x] Documentation updated
- [x] Tests
- [x] Ready to be merged

**Note: this is a breaking change**
