### PR TITLE
feat: use error boundary to capture useEffect errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
     "@babel/runtime": "^7.12.5",
     "@types/react": ">=16.9.0",
     "@types/react-dom": ">=16.9.0",
-    "@types/react-test-renderer": ">=16.9.0"
+    "@types/react-test-renderer": ">=16.9.0",
+    "filter-console": "^0.1.1",
+    "react-error-boundary": "^3.1.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.9.1",

--- a/src/dom/__tests__/errorHook.test.ts
+++ b/src/dom/__tests__/errorHook.test.ts
@@ -108,13 +108,7 @@ describe('error hook tests', () => {
     })
   })
 
-  /*
-    These tests capture error cases that are not currently being caught successfully.
-    Refer to https://github.com/testing-library/react-hooks-testing-library/issues/308
-    for more details.
-  */
-  // eslint-disable-next-line jest/no-disabled-tests
-  describe.skip('effect', () => {
+  describe('effect', () => {
     test('should raise effect error', () => {
       const { result } = renderHook(() => useEffectError(true))
 

--- a/src/helpers/createTestHarness.tsx
+++ b/src/helpers/createTestHarness.tsx
@@ -1,42 +1,65 @@
 import React, { Suspense } from 'react'
+import { ErrorBoundary, FallbackProps } from 'react-error-boundary'
+import filterConsole from 'filter-console'
+
+import { addCleanup } from '../core'
 
 import { RendererProps, WrapperComponent } from '../types/react'
 
-import { isPromise } from './promises'
-
-function TestComponent<TProps, TResult>({
-  hookProps,
-  callback,
-  setError,
-  setValue
-}: RendererProps<TProps, TResult> & { hookProps?: TProps }) {
-  try {
-    // coerce undefined into TProps, so it maintains the previous behaviour
-    setValue(callback(hookProps as TProps))
-  } catch (err: unknown) {
-    if (isPromise(err)) {
-      throw err
-    } else {
-      setError(err as Error)
+function suppressErrorOutput() {
+  // The error output from error boundaries is notoriously difficult to suppress.  To save
+  // out users from having to work it out, we crudely suppress the output matching the patterns
+  // below.  For more information, see these issues:
+  //   - https://github.com/testing-library/react-hooks-testing-library/issues/50
+  //   - https://github.com/facebook/react/issues/11098#issuecomment-412682721
+  //   - https://github.com/facebook/react/issues/15520
+  //   - https://github.com/facebook/react/issues/18841
+  const removeConsoleFilter = filterConsole(
+    [
+      /^The above error occurred in the <TestComponent> component:/, // error boundary output
+      /^Error: Uncaught .+/ // jsdom output
+    ],
+    {
+      methods: ['error']
     }
-  }
-  return null
+  )
+  addCleanup(removeConsoleFilter)
 }
 
 function createTestHarness<TProps, TResult>(
-  rendererProps: RendererProps<TProps, TResult>,
+  { callback, setValue, setError }: RendererProps<TProps, TResult>,
   Wrapper?: WrapperComponent<TProps>,
   suspense: boolean = true
 ) {
+  const TestComponent = ({ hookProps }: { hookProps?: TProps }) => {
+    // coerce undefined into TProps, so it maintains the previous behaviour
+    setValue(callback(hookProps as TProps))
+    return null
+  }
+
+  let resetErrorBoundary = () => {}
+  const ErrorFallback = ({ error, resetErrorBoundary: reset }: FallbackProps) => {
+    resetErrorBoundary = () => {
+      resetErrorBoundary = () => {}
+      reset()
+    }
+    setError(error)
+    return null
+  }
+
+  suppressErrorOutput()
+
   const testHarness = (props?: TProps) => {
-    let component = <TestComponent hookProps={props} {...rendererProps} />
+    resetErrorBoundary()
+
+    let component = <TestComponent hookProps={props} />
     if (Wrapper) {
       component = <Wrapper {...(props as TProps)}>{component}</Wrapper>
     }
     if (suspense) {
       component = <Suspense fallback={null}>{component}</Suspense>
     }
-    return component
+    return <ErrorBoundary FallbackComponent={ErrorFallback}>{component}</ErrorBoundary>
   }
 
   return testHarness

--- a/src/helpers/promises.ts
+++ b/src/helpers/promises.ts
@@ -2,13 +2,9 @@ function resolveAfter(ms: number) {
   return new Promise<void>((resolve) => setTimeout(resolve, ms))
 }
 
-export async function callAfter(callback: () => void, ms: number) {
+async function callAfter(callback: () => void, ms: number) {
   await resolveAfter(ms)
   callback()
 }
 
-function isPromise<T>(value: unknown): boolean {
-  return typeof (value as PromiseLike<T>).then === 'function'
-}
-
-export { isPromise, resolveAfter }
+export { resolveAfter, callAfter }

--- a/src/native/__tests__/errorHook.test.ts
+++ b/src/native/__tests__/errorHook.test.ts
@@ -108,13 +108,7 @@ describe('error hook tests', () => {
     })
   })
 
-  /*
-    These tests capture error cases that are not currently being caught successfully.
-    Refer to https://github.com/testing-library/react-hooks-testing-library/issues/308
-    for more details.
-  */
-  // eslint-disable-next-line jest/no-disabled-tests
-  describe.skip('effect', () => {
+  describe('effect', () => {
     test('should raise effect error', () => {
       const { result } = renderHook(() => useEffectError(true))
 

--- a/src/native/__tests__/resultHistory.test.ts
+++ b/src/native/__tests__/resultHistory.test.ts
@@ -1,34 +1,39 @@
 import { renderHook } from '..'
 
 describe('result history tests', () => {
-  let count = 0
-  function useCounter() {
-    const result = count++
-    if (result === 2) {
+  function useValue(value: number) {
+    if (value === 2) {
       throw Error('expected')
     }
-    return result
+    return value
   }
 
   test('should capture all renders states of hook', () => {
-    const { result, rerender } = renderHook(() => useCounter())
+    const { result, rerender } = renderHook((value) => useValue(value), {
+      initialProps: 0
+    })
 
     expect(result.current).toEqual(0)
     expect(result.all).toEqual([0])
 
-    rerender()
+    rerender(1)
 
     expect(result.current).toBe(1)
     expect(result.all).toEqual([0, 1])
 
-    rerender()
+    rerender(2)
 
     expect(result.error).toEqual(Error('expected'))
     expect(result.all).toEqual([0, 1, Error('expected')])
 
-    rerender()
+    rerender(3)
 
     expect(result.current).toBe(3)
     expect(result.all).toEqual([0, 1, Error('expected'), 3])
+
+    rerender()
+
+    expect(result.current).toBe(3)
+    expect(result.all).toEqual([0, 1, Error('expected'), 3, 3])
   })
 })

--- a/src/server/__tests__/errorHook.test.ts
+++ b/src/server/__tests__/errorHook.test.ts
@@ -119,13 +119,7 @@ describe('error hook tests', () => {
     })
   })
 
-  /*
-    These tests capture error cases that are not currently being caught successfully.
-    Refer to https://github.com/testing-library/react-hooks-testing-library/issues/308
-    for more details.
-  */
-  // eslint-disable-next-line jest/no-disabled-tests
-  describe.skip('effect', () => {
+  describe('effect', () => {
     test('should raise effect error', () => {
       const { result, hydrate } = renderHook(() => useEffectError(true))
 

--- a/src/server/__tests__/resultHistory.test.ts
+++ b/src/server/__tests__/resultHistory.test.ts
@@ -9,31 +9,36 @@ describe('result history tests', () => {
   }
 
   test('should capture all renders states of hook', () => {
-    const { result, rerender } = renderHook((value) => useValue(value), {
+    const { result, hydrate, rerender } = renderHook((value) => useValue(value), {
       initialProps: 0
     })
 
     expect(result.current).toEqual(0)
     expect(result.all).toEqual([0])
 
+    hydrate()
+
+    expect(result.current).toEqual(0)
+    expect(result.all).toEqual([0, 0])
+
     rerender(1)
 
     expect(result.current).toBe(1)
-    expect(result.all).toEqual([0, 1])
+    expect(result.all).toEqual([0, 0, 1])
 
     rerender(2)
 
     expect(result.error).toEqual(Error('expected'))
-    expect(result.all).toEqual([0, 1, Error('expected')])
+    expect(result.all).toEqual([0, 0, 1, Error('expected')])
 
     rerender(3)
 
     expect(result.current).toBe(3)
-    expect(result.all).toEqual([0, 1, Error('expected'), 3])
+    expect(result.all).toEqual([0, 0, 1, Error('expected'), 3])
 
     rerender()
 
     expect(result.current).toBe(3)
-    expect(result.all).toEqual([0, 1, Error('expected'), 3, 3])
+    expect(result.all).toEqual([0, 0, 1, Error('expected'), 3, 3])
   })
 })

--- a/src/server/pure.ts
+++ b/src/server/pure.ts
@@ -20,8 +20,12 @@ function createServerRenderer<TProps, TResult>(
     render(props?: TProps) {
       renderProps = props
       act(() => {
-        const serverOutput = ReactDOMServer.renderToString(testHarness(props))
-        container.innerHTML = serverOutput
+        try {
+          const serverOutput = ReactDOMServer.renderToString(testHarness(props))
+          container.innerHTML = serverOutput
+        } catch (e: unknown) {
+          rendererProps.setError(e as Error)
+        }
       })
     },
     hydrate() {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

Replace `try/catch` error handling with a an error boundary.

**Why**:

<!-- Why are these changes necessary? -->

Fixes #308

The error boundary will catch errors thrown in `useEffect` calls as well as in the render path.

**How**:

The challenge here and why we haven't done it sooner is the excessive amount of logging produced from React when an error boundary catches and error.  I've tried many official and unofficial approaches over the years but none have worked consistently as we changed renderers and new versions of React were released. For more information, see these issues:
  - https://github.com/testing-library/react-hooks-testing-library/issues/50
  - https://github.com/facebook/react/issues/11098#issuecomment-412682721
  - https://github.com/facebook/react/issues/15520
  - https://github.com/facebook/react/issues/18841

In this proposal, I used a package called [filter-console](https://www.npmjs.com/package/filter-console) to prevent errors matching a specific patterns from being logged.  This is potentially brittle if new versions of React change the log format, but we can add more patterns or change the existing ones if they ever do 🤷‍♂️ 

I also opted to use `react-error-boundary` as it provided some nice features for resetting the error state when rerendering.  The way I access the reset functionality is a bit clunky, so I'm open to suggestions on how to clean that up.

**Checklist**:

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

We had a bunch of tests marked as `.skip` for testing the effect errors that I have unmarked and they all work now, which is a good sign.

The other tests that needed updating was the `result history tests` .  The hook used in those tests actually had a side effect from rendering that the `try/catch` was hiding, but the error boundary showed the results appearing out of order because the [error handling triggered an additional render](https://github.com/facebook/react/issues/16130#issuecomment-521637592) that cause the next result to jump ahead in the array.  It was painful to debug, but the new tests worked against the old implementation and as well as the new one.  