### PR TITLE
feat: add option to not suppress error output if desired

### DIFF
--- a/src/dom/__tests__/errorHook.test.ts
+++ b/src/dom/__tests__/errorHook.test.ts
@@ -142,4 +142,42 @@ describe('error hook tests', () => {
       expect(result.error).toBe(undefined)
     })
   })
+
+  describe('error output suppression', () => {
+    const originalConsoleError = console.error
+    const mockConsoleError = jest.fn()
+
+    beforeEach(() => {
+      console.error = mockConsoleError
+    })
+
+    afterEach(() => {
+      console.error = originalConsoleError
+    })
+
+    test('should suppress error output', () => {
+      const { result } = renderHook(() => useError(true), {
+        suppressErrorOutput: true
+      })
+
+      expect(result.error).toEqual(Error('expected'))
+      expect(mockConsoleError).toBeCalledTimes(0)
+    })
+
+    test('should not suppress error output', () => {
+      const { result } = renderHook(() => useError(true), {
+        suppressErrorOutput: false
+      })
+
+      expect(result.error).toEqual(Error('expected'))
+      expect(mockConsoleError).toBeCalledWith(
+        expect.stringMatching(/^Error: Uncaught \[Error: expected\]/),
+        expect.any(Error)
+      )
+      expect(mockConsoleError).toBeCalledWith(
+        expect.stringMatching(/^The above error occurred in the <TestComponent> component:/)
+      )
+      expect(mockConsoleError).toBeCalledTimes(2)
+    })
+  })
 })

--- a/src/dom/pure.ts
+++ b/src/dom/pure.ts
@@ -8,10 +8,10 @@ import { createTestHarness } from '../helpers/createTestHarness'
 
 function createDomRenderer<TProps, TResult>(
   rendererProps: RendererProps<TProps, TResult>,
-  { wrapper }: RendererOptions<TProps>
+  options: RendererOptions<TProps>
 ) {
   const container = document.createElement('div')
-  const testHarness = createTestHarness(rendererProps, wrapper)
+  const testHarness = createTestHarness(rendererProps, options)
 
   return {
     render(props?: TProps) {

--- a/src/helpers/createTestHarness.tsx
+++ b/src/helpers/createTestHarness.tsx
@@ -4,11 +4,11 @@ import filterConsole from 'filter-console'
 
 import { addCleanup } from '../core'
 
-import { RendererProps, WrapperComponent } from '../types/react'
+import { RendererProps, RendererOptions } from '../types/react'
 
-function suppressErrorOutput() {
+function filterErrorOutput() {
   // The error output from error boundaries is notoriously difficult to suppress.  To save
-  // out users from having to work it out, we crudely suppress the output matching the patterns
+  // our users from having to work it out, we crudely suppress the output matching the patterns
   // below.  For more information, see these issues:
   //   - https://github.com/testing-library/react-hooks-testing-library/issues/50
   //   - https://github.com/facebook/react/issues/11098#issuecomment-412682721
@@ -28,7 +28,7 @@ function suppressErrorOutput() {
 
 function createTestHarness<TProps, TResult>(
   { callback, setValue, setError }: RendererProps<TProps, TResult>,
-  Wrapper?: WrapperComponent<TProps>,
+  { wrapper: Wrapper, suppressErrorOutput = true }: RendererOptions<TProps>,
   suspense: boolean = true
 ) {
   const TestComponent = ({ hookProps }: { hookProps?: TProps }) => {
@@ -47,7 +47,9 @@ function createTestHarness<TProps, TResult>(
     return null
   }
 
-  suppressErrorOutput()
+  if (suppressErrorOutput) {
+    filterErrorOutput()
+  }
 
   const testHarness = (props?: TProps) => {
     resetErrorBoundary()

--- a/src/native/pure.ts
+++ b/src/native/pure.ts
@@ -7,10 +7,10 @@ import { createTestHarness } from '../helpers/createTestHarness'
 
 function createNativeRenderer<TProps, TResult>(
   rendererProps: RendererProps<TProps, TResult>,
-  { wrapper }: RendererOptions<TProps>
+  options: RendererOptions<TProps>
 ) {
   let container: ReactTestRenderer
-  const testHarness = createTestHarness(rendererProps, wrapper)
+  const testHarness = createTestHarness(rendererProps, options)
 
   return {
     render(props?: TProps) {

--- a/src/server/pure.ts
+++ b/src/server/pure.ts
@@ -9,12 +9,12 @@ import { createTestHarness } from '../helpers/createTestHarness'
 
 function createServerRenderer<TProps, TResult>(
   rendererProps: RendererProps<TProps, TResult>,
-  { wrapper }: RendererOptions<TProps>
+  options: RendererOptions<TProps>
 ) {
   let renderProps: TProps | undefined
   let hydrated = false
   const container = document.createElement('div')
-  const testHarness = createTestHarness(rendererProps, wrapper, false)
+  const testHarness = createTestHarness(rendererProps, options, false)
 
   return {
     render(props?: TProps) {

--- a/src/types/react.ts
+++ b/src/types/react.ts
@@ -11,6 +11,7 @@ export type WrapperComponent<TProps> = ComponentType<TProps>
 
 export type RendererOptions<TProps> = {
   wrapper?: WrapperComponent<TProps>
+  suppressErrorOutput?: boolean
 }
 
 export type RenderHookOptions<TProps> = BaseRenderHookOptions<TProps> & {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

Add `suppressErrorOutput` option (default to `true`) to allow disabling of the `console.error` suppression we added with the error boundary fix for `useEffect` errors.

**Why**:

<!-- Why are these changes necessary? -->

It was [mentioned in discord](https://discord.com/channels/723559267868737556/723852521734668299/799444299870896169) that it might be causing issues for some people as its nuked their own console mocks.

**How**:

<!-- How were these changes implemented? -->

Just a `boolean` option an a `if` statement to skip over the call that uses `filter-console`.

**Checklist**:

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [x] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

I've put this up for discussion to see if:

1. this is something we want to add and support
2. is there a better way we could have handled the error logs than this

Any feedback is welcome.
