### PR TITLE
fix: reduce console.error suppressions to only while acting

### DIFF
--- a/disable-error-filtering.js
+++ b/disable-error-filtering.js
@@ -1,0 +1,1 @@
+process.env.RHTL_DISABLE_ERROR_FILTERING = true

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -12,6 +12,7 @@ route: '/reference/api'
 - [`cleanup`](/reference/api#cleanup)
 - [`addCleanup`](/reference/api#addcleanup)
 - [`removeCleanup`](/reference/api#removecleanup)
+- [`console.error`](/reference/api#consoleerror)
 
 ---
 
@@ -154,7 +155,7 @@ module.exports = {
 ```
 
 Alternatively, you can change your test to import from `@testing-library/react-hooks/pure` instead
-of the regular imports. This applys to any of our export methods documented in
+of the regular imports. This applies to any of our export methods documented in
 [Rendering](/installation#being-specific).
 
 ```diff
@@ -270,3 +271,49 @@ Interval checking is disabled if `interval` is not provided as a `falsy`.
 _Default: 1000_
 
 The maximum amount of time in milliseconds (ms) to wait.
+
+---
+
+## `console.error`
+
+In order to catch errors that are produced in all parts of the hook's lifecycle, the test harness
+used to wrap the hook call includes an
+[Error Boundary](https://reactjs.org/docs/error-boundaries.html) which causes a
+[significant amount of output noise](https://reactjs.org/docs/error-boundaries.html#component-stack-traces)
+in tests.
+
+To keep test output clean, we patch `console.error` when `renderHook` is called to filter out the
+unnecessary logging and restore the original version during cleanup. This side-effect can affect
+tests that also patch `console.error` (e.g. to assert a specific error message get logged) by
+replacing their custom implementation as well.
+
+### Disabling `console.error` filtering
+
+Importing `@testing-library/react-hooks/disable-error-filtering.js` in test setup files disable the
+error filtering feature and not patch `console.error` in any way.
+
+For example, in [Jest](https://jestjs.io/) this can be added to your
+[Jest config](https://jestjs.io/docs/configuration):
+
+```js
+module.exports = {
+  setupFilesAfterEnv: [
+    '@testing-library/react-hooks/disable-error-filtering.js'
+    // other setup files
+  ]
+}
+```
+
+Alternatively, you can change your test to import from `@testing-library/react-hooks/pure` instead
+of the regular imports. This applies to any of our export methods documented in
+[Rendering](/installation#being-specific).
+
+```diff
+- import { renderHook, cleanup, act } from '@testing-library/react-hooks'
++ import { renderHook, cleanup, act } from '@testing-library/react-hooks/pure'
+```
+
+If neither of these approaches are suitable, setting the `RHTL_DISABLE_ERROR_FILTERING` environment
+variable to `true` before importing `@testing-library/react-hooks` will also disable this feature.
+
+> Please note that this may result is a significant amount of additional logging in you test output.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "native",
     "server",
     "pure",
+    "disable-error-filtering.js",
     "dont-cleanup-after-each.js"
   ],
   "author": "Michael Peyper <mpeyper7@gmail.com>",

--- a/src/dom/__tests__/errorSuppression.disabled.test.ts
+++ b/src/dom/__tests__/errorSuppression.disabled.test.ts
@@ -1,0 +1,39 @@
+import { renderHook } from '..'
+
+describe('error output suppression (disabled) tests', () => {
+  function useError(throwError?: boolean) {
+    if (throwError) {
+      throw new Error('expected')
+    }
+    return true
+  }
+
+  const originalConsoleError = console.error
+  const mockConsoleError = jest.fn()
+
+  beforeAll(() => {
+    process.env.RHTL_DISABLE_ERROR_FILTERING = 'true'
+  })
+
+  beforeEach(() => {
+    console.error = mockConsoleError
+  })
+
+  afterEach(() => {
+    console.error = originalConsoleError
+  })
+
+  test('should not suppress error output', () => {
+    const { result } = renderHook(() => useError(true))
+
+    expect(result.error).toEqual(Error('expected'))
+    expect(mockConsoleError).toBeCalledWith(
+      expect.stringMatching(/^Error: Uncaught \[Error: expected\]/),
+      expect.any(Error)
+    )
+    expect(mockConsoleError).toBeCalledWith(
+      expect.stringMatching(/^The above error occurred in the <TestComponent> component:/)
+    )
+    expect(mockConsoleError).toBeCalledTimes(2)
+  })
+})

--- a/src/dom/__tests__/errorSuppression.pure.test.ts
+++ b/src/dom/__tests__/errorSuppression.pure.test.ts
@@ -1,0 +1,35 @@
+import { renderHook } from '../pure'
+
+describe('error output suppression (pure) tests', () => {
+  function useError(throwError?: boolean) {
+    if (throwError) {
+      throw new Error('expected')
+    }
+    return true
+  }
+
+  const originalConsoleError = console.error
+  const mockConsoleError = jest.fn()
+
+  beforeEach(() => {
+    console.error = mockConsoleError
+  })
+
+  afterEach(() => {
+    console.error = originalConsoleError
+  })
+
+  test('should not suppress error output', () => {
+    const { result } = renderHook(() => useError(true))
+
+    expect(result.error).toEqual(Error('expected'))
+    expect(mockConsoleError).toBeCalledWith(
+      expect.stringMatching(/^Error: Uncaught \[Error: expected\]/),
+      expect.any(Error)
+    )
+    expect(mockConsoleError).toBeCalledWith(
+      expect.stringMatching(/^The above error occurred in the <TestComponent> component:/)
+    )
+    expect(mockConsoleError).toBeCalledTimes(2)
+  })
+})

--- a/src/dom/index.ts
+++ b/src/dom/index.ts
@@ -1,5 +1,7 @@
 import { autoRegisterCleanup } from '../core/cleanup'
+import { enableErrorOutputSuppression } from '../helpers/console'
 
 autoRegisterCleanup()
+enableErrorOutputSuppression()
 
 export * from './pure'

--- a/src/dom/pure.ts
+++ b/src/dom/pure.ts
@@ -1,10 +1,13 @@
 import ReactDOM from 'react-dom'
-import { act } from 'react-dom/test-utils'
+import { act as baseAct } from 'react-dom/test-utils'
 
-import { RendererProps, RendererOptions } from '../types/react'
+import { RendererProps, RendererOptions, Act } from '../types/react'
 
 import { createRenderHook } from '../core'
+import { createActWrapper } from '../helpers/act'
 import { createTestHarness } from '../helpers/createTestHarness'
+
+const act = createActWrapper(baseAct)
 
 function createDomRenderer<TProps, TResult>(
   rendererProps: RendererProps<TProps, TResult>,

--- a/src/helpers/act.ts
+++ b/src/helpers/act.ts
@@ -1,0 +1,28 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { Act } from '../types/react'
+
+import { suppressErrorOutput } from './console'
+
+function createActWrapper(baseAct: Act) {
+  const act: Act = async (callback: () => any) => {
+    const restoreOutput = suppressErrorOutput()
+    try {
+      let awaitRequired = false
+      const actResult = (baseAct(() => {
+        const callbackResult = callback()
+        awaitRequired = callbackResult !== undefined && !!callbackResult.then
+        return callbackResult
+      }) as any) as PromiseLike<undefined>
+
+      return awaitRequired ? await actResult : undefined
+    } finally {
+      restoreOutput()
+    }
+  }
+
+  return act
+}
+
+export { createActWrapper }

--- a/src/helpers/act.ts
+++ b/src/helpers/act.ts
@@ -1,21 +1,19 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { Act } from '../types/react'
 
 import { suppressErrorOutput } from './console'
 
+import { isPromise } from './promises'
+
 function createActWrapper(baseAct: Act) {
-  const act: Act = async (callback: () => any) => {
+  const act: Act = async (callback: () => unknown) => {
     const restoreOutput = suppressErrorOutput()
     try {
       let awaitRequired = false
-      const actResult = (baseAct(() => {
+      const actResult = baseAct(() => {
         const callbackResult = callback()
-        awaitRequired = callbackResult !== undefined && !!callbackResult.then
-        return callbackResult
-      }) as any) as PromiseLike<undefined>
-
+        awaitRequired = isPromise(callbackResult)
+        return callbackResult as Promise<void>
+      })
       return awaitRequired ? await actResult : undefined
     } finally {
       restoreOutput()

--- a/src/helpers/console.ts
+++ b/src/helpers/console.ts
@@ -1,6 +1,16 @@
 import filterConsole from 'filter-console'
 
+let errorOutputSuppressionEnabled = false
+
+function enableErrorOutputSuppression() {
+  errorOutputSuppressionEnabled = true
+}
+
 function suppressErrorOutput() {
+  if (!errorOutputSuppressionEnabled || process.env.RHTL_DISABLE_ERROR_FILTERING) {
+    return () => {}
+  }
+
   // The error output from error boundaries is notoriously difficult to suppress.  To save
   // our users from having to work it out, we crudely suppress the output matching the patterns
   // below.  For more information, see these issues:
@@ -19,4 +29,4 @@ function suppressErrorOutput() {
   )
 }
 
-export { suppressErrorOutput }
+export { enableErrorOutputSuppression, suppressErrorOutput }

--- a/src/helpers/console.ts
+++ b/src/helpers/console.ts
@@ -1,0 +1,22 @@
+import filterConsole from 'filter-console'
+
+function suppressErrorOutput() {
+  // The error output from error boundaries is notoriously difficult to suppress.  To save
+  // our users from having to work it out, we crudely suppress the output matching the patterns
+  // below.  For more information, see these issues:
+  //   - https://github.com/testing-library/react-hooks-testing-library/issues/50
+  //   - https://github.com/facebook/react/issues/11098#issuecomment-412682721
+  //   - https://github.com/facebook/react/issues/15520
+  //   - https://github.com/facebook/react/issues/18841
+  return filterConsole(
+    [
+      /^The above error occurred in the <TestComponent> component:/, // error boundary output
+      /^Error: Uncaught .+/ // jsdom output
+    ],
+    {
+      methods: ['error']
+    }
+  )
+}
+
+export { suppressErrorOutput }

--- a/src/helpers/createTestHarness.tsx
+++ b/src/helpers/createTestHarness.tsx
@@ -1,30 +1,7 @@
 import React, { Suspense } from 'react'
 import { ErrorBoundary, FallbackProps } from 'react-error-boundary'
-import filterConsole from 'filter-console'
-
-import { addCleanup } from '../core'
 
 import { RendererProps, WrapperComponent } from '../types/react'
-
-function suppressErrorOutput() {
-  // The error output from error boundaries is notoriously difficult to suppress.  To save
-  // out users from having to work it out, we crudely suppress the output matching the patterns
-  // below.  For more information, see these issues:
-  //   - https://github.com/testing-library/react-hooks-testing-library/issues/50
-  //   - https://github.com/facebook/react/issues/11098#issuecomment-412682721
-  //   - https://github.com/facebook/react/issues/15520
-  //   - https://github.com/facebook/react/issues/18841
-  const removeConsoleFilter = filterConsole(
-    [
-      /^The above error occurred in the <TestComponent> component:/, // error boundary output
-      /^Error: Uncaught .+/ // jsdom output
-    ],
-    {
-      methods: ['error']
-    }
-  )
-  addCleanup(removeConsoleFilter)
-}
 
 function createTestHarness<TProps, TResult>(
   { callback, setValue, setError }: RendererProps<TProps, TResult>,
@@ -46,8 +23,6 @@ function createTestHarness<TProps, TResult>(
     setError(error)
     return null
   }
-
-  suppressErrorOutput()
 
   const testHarness = (props?: TProps) => {
     resetErrorBoundary()

--- a/src/helpers/promises.ts
+++ b/src/helpers/promises.ts
@@ -7,8 +7,8 @@ async function callAfter(callback: () => void, ms: number) {
   callback()
 }
 
-function isPromise<T>(value: unknown): boolean {
-  return value !== undefined && typeof (value as PromiseLike<T>).then === 'function'
+function isPromise(value: unknown): boolean {
+  return value !== undefined && typeof (value as PromiseLike<unknown>).then === 'function'
 }
 
 export { resolveAfter, callAfter, isPromise }

--- a/src/helpers/promises.ts
+++ b/src/helpers/promises.ts
@@ -7,4 +7,8 @@ async function callAfter(callback: () => void, ms: number) {
   callback()
 }
 
-export { resolveAfter, callAfter }
+function isPromise<T>(value: unknown): boolean {
+  return value !== undefined && typeof (value as PromiseLike<T>).then === 'function'
+}
+
+export { resolveAfter, callAfter, isPromise }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 import { autoRegisterCleanup } from './core/cleanup'
+import { enableErrorOutputSuppression } from './helpers/console'
 
 autoRegisterCleanup()
+enableErrorOutputSuppression()
 
 export * from './pure'

--- a/src/native/index.ts
+++ b/src/native/index.ts
@@ -1,5 +1,7 @@
 import { autoRegisterCleanup } from '../core/cleanup'
+import { enableErrorOutputSuppression } from '../helpers/console'
 
 autoRegisterCleanup()
+enableErrorOutputSuppression()
 
 export * from './pure'

--- a/src/native/pure.ts
+++ b/src/native/pure.ts
@@ -1,9 +1,12 @@
-import { act, create, ReactTestRenderer } from 'react-test-renderer'
+import { act as baseAct, create, ReactTestRenderer } from 'react-test-renderer'
 
-import { RendererProps, RendererOptions } from '../types/react'
+import { RendererProps, RendererOptions, Act } from '../types/react'
 
 import { createRenderHook } from '../core'
+import { createActWrapper } from '../helpers/act'
 import { createTestHarness } from '../helpers/createTestHarness'
+
+const act = createActWrapper(baseAct)
 
 function createNativeRenderer<TProps, TResult>(
   rendererProps: RendererProps<TProps, TResult>,

--- a/src/server/__tests__/errorHook.test.ts
+++ b/src/server/__tests__/errorHook.test.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 
-import { renderHook } from '..'
+import { renderHook, act } from '..'
 
 describe('error hook tests', () => {
   function useError(throwError?: boolean) {
@@ -161,6 +161,55 @@ describe('error hook tests', () => {
 
       expect(result.current).not.toBe(undefined)
       expect(result.error).toBe(undefined)
+    })
+  })
+
+  describe('error output suppression', () => {
+    test('should allow console.error to be mocked', async () => {
+      const consoleError = console.error
+      console.error = jest.fn()
+
+      try {
+        const { hydrate, rerender, unmount } = renderHook(
+          (stage) => {
+            useEffect(() => {
+              console.error(`expected in effect`)
+              return () => {
+                console.error(`expected in unmount`)
+              }
+            }, [])
+            console.error(`expected in ${stage}`)
+          },
+          {
+            initialProps: 'render'
+          }
+        )
+
+        hydrate()
+
+        act(() => {
+          console.error('expected in act')
+        })
+
+        await act(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 100))
+          console.error('expected in async act')
+        })
+
+        rerender('rerender')
+
+        unmount()
+
+        expect(console.error).toBeCalledWith('expected in render') // twice render/hydrate
+        expect(console.error).toBeCalledWith('expected in effect')
+        expect(console.error).toBeCalledWith('expected in act')
+        expect(console.error).toBeCalledWith('expected in async act')
+        expect(console.error).toBeCalledWith('expected in rerender')
+        expect(console.error).toBeCalledWith('expected in unmount')
+        expect(console.error).toBeCalledTimes(7)
+      } finally {
+        console.error = consoleError
+      }
     })
   })
 })

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,5 +1,7 @@
 import { autoRegisterCleanup } from '../core/cleanup'
+import { enableErrorOutputSuppression } from '../helpers/console'
 
 autoRegisterCleanup()
+enableErrorOutputSuppression()
 
 export * from './pure'

--- a/src/server/pure.ts
+++ b/src/server/pure.ts
@@ -1,11 +1,14 @@
 import ReactDOMServer from 'react-dom/server'
 import ReactDOM from 'react-dom'
-import { act } from 'react-dom/test-utils'
+import { act as baseAct } from 'react-dom/test-utils'
 
-import { RendererProps, RendererOptions } from '../types/react'
+import { RendererProps, RendererOptions, Act } from '../types/react'
 
 import { createRenderHook } from '../core'
+import { createActWrapper } from '../helpers/act'
 import { createTestHarness } from '../helpers/createTestHarness'
+
+const act = createActWrapper(baseAct)
 
 function createServerRenderer<TProps, TResult>(
   rendererProps: RendererProps<TProps, TResult>,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

Another option vs #541 

**Why**:

<!-- Why are these changes necessary? -->

Making it _just work_ for more users without having to set options.

**How**:

<!-- How were these changes implemented? -->

By only suppressing the error boundary output while `act`ing, the test code retains access to the unaltered (or altered in their own way) version of `console.error`.

Technically, the test code will have access to our suppressed version of `console.error` within an `act` callback, however they would have to be using it for something other than logging an error (e.g. asserting a mocked version was called) within that callback to have an issue.  Calling it to log an error with it would work as expected.

There is an option to return the unaltered `act` to them and only use the wrapped version internally around `render` calls, which would alleviate the above issue, however that might leave them susceptible to showing the output if their `act` update caused and error in the subsequent render passes.

The tradeoff with this implementation is that we cannot pass an option to disable it like in #541 as the `act` function needs to be wrapped in the global scope before the the renderer receives the options.  We could potentially use an environment variable to disable is globally [like we do for other things](https://github.com/testing-library/react-hooks-testing-library/blob/master/dont-cleanup-after-each.js#L1) if we really want an escape hatch on it.

**Checklist**:

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

The code here is pretty crude, especially in the `act` wrapper.  I'll clean it up if we want to go this way.