### PR TITLE
refactor: reduce eslint-warnings & type changes

### DIFF
--- a/src/helpers/act.ts
+++ b/src/helpers/act.ts
@@ -1,21 +1,19 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { Act } from '../types/react'
 
 import { suppressErrorOutput } from './console'
 
+import { isPromise } from './promises'
+
 function createActWrapper(baseAct: Act) {
-  const act: Act = async (callback: () => any) => {
+  const act: Act = async (callback: () => unknown) => {
     const restoreOutput = suppressErrorOutput()
     try {
       let awaitRequired = false
-      const actResult = (baseAct(() => {
+      const actResult = baseAct(() => {
         const callbackResult = callback()
-        awaitRequired = callbackResult !== undefined && !!callbackResult.then
-        return callbackResult
-      }) as any) as PromiseLike<undefined>
-
+        awaitRequired = isPromise(callbackResult)
+        return callbackResult as Promise<void>
+      })
       return awaitRequired ? await actResult : undefined
     } finally {
       restoreOutput()

--- a/src/helpers/promises.ts
+++ b/src/helpers/promises.ts
@@ -7,4 +7,8 @@ async function callAfter(callback: () => void, ms: number) {
   callback()
 }
 
-export { resolveAfter, callAfter }
+function isPromise<T>(value: unknown): boolean {
+  return value !== undefined && typeof (value as PromiseLike<T>).then === 'function'
+}
+
+export { resolveAfter, callAfter, isPromise }


### PR DESCRIPTION
I think we removed `isPromise` thinking we didn't need it, but it rears it's head again! I also added the undefined bit just to make the act wrapper function a bit cleaner. 