### PR TITLE
fix docs aipReference asyncUtils

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -108,7 +108,7 @@ called.
 ### `...asyncUtils`
 
 Utilities to assist with testing asynchronous behaviour. See the
-[Async Utils](/reference/api#async-utilities) section for more details.
+[Async Utils](https://react-hooks-testing-library.com/reference/api#async-utilities) section for more details.
 
 ---
 


### PR DESCRIPTION
https://github.com/testing-library/react-hooks-testing-library/blob/master/docs/api-reference.md#asyncutils 

`See the Async Utils section for more details.`  link is broken.