### PR TITLE
Fix typos in api-reference.md

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -474,6 +474,15 @@
         "review",
         "code"
       ]
+    },
+    {
+      "login": "mrseanbaines",
+      "name": "Sean Baines",
+      "avatar_url": "https://avatars.githubusercontent.com/u/24367010?v=4",
+      "profile": "https://seanbaines.com/",
+      "contributions": [
+        "doc"
+      ]
     }
   ],
   "skipCi": true,

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
+
 - [The problem](#the-problem)
 - [The solution](#the-solution)
 - [When to use this library](#when-to-use-this-library)
@@ -232,6 +233,9 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/cliffzhaobupt"><img src="https://avatars3.githubusercontent.com/u/7374506?v=4?s=100" width="100px;" alt=""/><br /><sub><b>cliffzhaobupt</b></sub></a><br /><a href="#maintenance-cliffzhaobupt" title="Maintenance">🚧</a></td>
     <td align="center"><a href="https://github.com/jonkoops"><img src="https://avatars2.githubusercontent.com/u/695720?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Jon Koops</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=jonkoops" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/jpeyper"><img src="https://avatars2.githubusercontent.com/u/6560018?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Jonathan Peyper</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/pulls?q=is%3Apr+reviewed-by%3Ajpeyper" title="Reviewed Pull Requests">👀</a> <a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=jpeyper" title="Code">💻</a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="https://seanbaines.com/"><img src="https://avatars.githubusercontent.com/u/24367010?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Sean Baines</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=mrseanbaines" title="Documentation">📖</a></td>
   </tr>
 </table>
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -314,4 +314,5 @@ of the [other non-pure imports](/installation#pure-imports)) instead of the regu
 If neither of these approaches are suitable, setting the `RHTL_DISABLE_ERROR_FILTERING` environment
 variable to `true` before importing `@testing-library/react-hooks` will also disable this feature.
 
-> Please note that this may result is a significant amount of additional logging in you test output.
+> Please note that this may result in a significant amount of additional logging in your test
+> output.


### PR DESCRIPTION
**What**:

Fixed a couple of small grammatical errors in the `api-reference.md` doc.

**Why**:

The grammar/wording was incorrect.

**How**:

Changed the wording.

**Checklist**:

- [x] Documentation updated
- [x] Ready to be merged
- [x] Added myself to contributors table
