### PR TITLE
Fixed a typo in the documentation

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -48,7 +48,7 @@ the results.
 
 ### When to use this library
 
-1. You're writing a library with one or more custom hooks that are not directly tied a component
+1. You're writing a library with one or more custom hooks that are not directly tied to a component
 2. You have a complex hook that is difficult to test through component interactions
 
 ### When not to use this library


### PR DESCRIPTION
Fixed a typo on the [official library website.](https://react-hooks-testing-library.com)
