### PR TITLE
Add ability to run SSR tests in pure-node environment

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -519,6 +519,16 @@
       "contributions": [
         "maintenance"
       ]
+    },
+    {
+      "login": "xobotyi",
+      "name": "Anton Zinovyev",
+      "avatar_url": "https://avatars.githubusercontent.com/u/6178739?v=4",
+      "profile": "https://github.com/xobotyi",
+      "contributions": [
+        "bug",
+        "code"
+      ]
     }
   ],
   "skipCi": true,

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://aleksandar.xyz"><img src="https://avatars.githubusercontent.com/u/7226555?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Aleksandar Grbic</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=agjs" title="Documentation">📖</a></td>
     <td align="center"><a href="https://github.com/yoniholmes"><img src="https://avatars.githubusercontent.com/u/184589?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Jonathan Holmes</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=yoniholmes" title="Code">💻</a></td>
     <td align="center"><a href="https://michaeldeboey.be"><img src="https://avatars.githubusercontent.com/u/6643991?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Michaël De Boey</b></sub></a><br /><a href="#maintenance-MichaelDeBoey" title="Maintenance">🚧</a></td>
+    <td align="center"><a href="https://github.com/xobotyi"><img src="https://avatars.githubusercontent.com/u/6178739?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Anton Zinovyev</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/issues?q=author%3Axobotyi" title="Bug reports">🐛</a> <a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=xobotyi" title="Code">💻</a></td>
   </tr>
 </table>
 


### PR DESCRIPTION
**What**:
Fix: #605

**Why**:
Before that change it was impossible to run SSR test in pure-nod eenvironment, where no DOM global objects exists.

**How**:
Div element now created only in hydration stage (also now it is a marker of hydration occurred)

**Checklist**:
- [ ] Documentation updated
- [ ] Tests
- [x] Ready to be merged
- [x] Added myself to contributors table