### PR TITLE
fix(types) Correct overload order for act without strictNullChecks in TypeScript

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -547,6 +547,15 @@
       "contributions": [
         "maintenance"
       ]
+    },
+    {
+      "login": "andyrooger",
+      "name": "andyrooger",
+      "avatar_url": "https://avatars.githubusercontent.com/u/420834?v=4",
+      "profile": "https://github.com/andyrooger",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "skipCi": true,

--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
   </tr>
   <tr>
     <td align="center"><a href="https://matan.io"><img src="https://avatars.githubusercontent.com/u/12711091?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Matan Borenkraout</b></sub></a><br /><a href="#maintenance-MatanBobi" title="Maintenance">🚧</a></td>
+    <td align="center"><a href="https://github.com/andyrooger"><img src="https://avatars.githubusercontent.com/u/420834?v=4?s=100" width="100px;" alt=""/><br /><sub><b>andyrooger</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=andyrooger" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -64,8 +64,8 @@ export type RenderHookOptions<TProps> = {
 }
 
 export type Act = {
-  (callback: () => void | undefined): void
   (callback: () => Promise<void | undefined>): Promise<undefined>
+  (callback: () => void | undefined): void
 }
 
 export type CleanupCallback = () => Promise<void> | void


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

Correct the TypeScript definitions, so that we produce the correct return type for `act(...)` calls when `strictNullChecks` is turned off.

**Why**:

Take the following code

```ts
import { act } from '@testing-library/react-hooks'

const result = act(() => Promise.resolve())
```
With `strictNullChecks` turned on, the type of `result` is `Promise<undefined>` as you would expect.
Turn `strictNullChecks` off, and the type of `result` is now `void`.

This is particularly highlighted in my case as the project I'm working on has eslint rules that will complain if we try to await a value it thinks is not thenable.

**How**:

It seems the issue is that with `strictNullChecks`, the two overloads for `act(...)` do not have a lot of overlap so the order we specify them in doesn't matter. Without `strictNullChecks`, anything that matches the async overload also matches the sync overload. Since the sync overload is specified first, it is always chosen.

I've just swapped the overloads around so that the more specific one with Promises is checked first.

**Checklist**:

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
