### PR TITLE
docs: fix for failing docz build

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "docz-theme-default": "1.2.0",
     "docz-utils": "2.3.0",
     "eslint": "7.31.0",
+    "get-pkg-repo": "4.1.1",
     "kcd-scripts": "11.2.0",
     "prettier": "^2.2.1",
     "react": "17.0.2",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

Temporary fix for the Docz build.

**Why**:

It's failing due to a dependency that introduced a breaking change.

**How**:

Pin the troublesome dependency to a compatible version as suggested [here](https://github.com/doczjs/docz/issues/1635#issuecomment-888953896) by @silviuaavram.

**Checklist**:

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- feel free to add additional comments -->

I'll merge this one the deploy preview build passes (and the other checks of course).

As a side note, I'm half way through porting the docs to docusaurus, so this fix is simply to allow current/future PRs to pass the deploy preview checks until the the migration is complete. 
