### PR TITLE
Pr/fix typo in docs

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -584,6 +584,15 @@
       "contributions": [
         "test"
       ]
+    },
+    {
+      "login": "masious",
+      "name": "Masious",
+      "avatar_url": "https://avatars.githubusercontent.com/u/6429009?v=4",
+      "profile": "https://www.facebook.com/masoud.bonabi",
+      "contributions": [
+        "doc"
+      ]
     }
   ],
   "skipCi": true,

--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/bdwain"><img src="https://avatars.githubusercontent.com/u/3982094?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Bryan Wain</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/issues?q=author%3Abdwain" title="Bug reports">🐛</a> <a href="https://github.com/testing-library/react-hooks-testing-library/pulls?q=is%3Apr+reviewed-by%3Abdwain" title="Reviewed Pull Requests">👀</a></td>
     <td align="center"><a href="https://github.com/snowystinger"><img src="https://avatars.githubusercontent.com/u/698229?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Robert Snow</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=snowystinger" title="Tests">⚠️</a></td>
     <td align="center"><a href="https://github.com/chris110408"><img src="https://avatars.githubusercontent.com/u/10645051?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Chris Chen</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=chris110408" title="Tests">⚠️</a></td>
+    <td align="center"><a href="https://www.facebook.com/masoud.bonabi"><img src="https://avatars.githubusercontent.com/u/6429009?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Masious</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=masious" title="Documentation">📖</a></td>
   </tr>
 </table>
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -68,7 +68,7 @@ The `renderHook` function returns an object that has the following properties:
 }
 ```
 
-The `current` value or the `result` will reflect the latest of whatever is returned from the
+The `current` value of the `result` will reflect the latest of whatever is returned from the
 `callback` passed to `renderHook`. Any thrown values from the latest call will be reflected in the
 `error` value of the `result`. The `all` value is an array containing all the returns (including the
 most recent) from the callback. These could be `result` or an `error` depending on what the callback


### PR DESCRIPTION
**What**:

The change is a typo fix.

**Why**:

<!-- Why are these changes necessary? -->
Currently, the documentation is implying that the return value of the `renderHook` result is the same as `current` which is wrong. This PR fixes the implication.

**How**:

Just by changing a character in the docs!

**Checklist**:

- [x ] Documentation updated
- [x ] Ready to be merged
- [x ] Added me to the contributors' table
