### PR TITLE
Update Act type signature

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -602,6 +602,15 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "andersonvom",
+      "name": "Anderson Mesquita",
+      "avatar_url": "https://avatars.githubusercontent.com/u/69922?v=4",
+      "profile": "https://github.com/andersonvom",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "skipCi": true,

--- a/README.md
+++ b/README.md
@@ -146,9 +146,9 @@ to test against. It also does not come installed with a specific renderer, we cu
 [`react-test-renderer`](https://www.npmjs.com/package/react-test-renderer) and
 [`react-dom`](https://www.npmjs.com/package/react-dom). You only need to install one of them,
 however, if you do have both installed, we will use `react-test-renderer` as the default. For more
-information see the [installation docs](https://react-hooks-testing-library.com/installation#renderer).
-Generally, the installed versions for `react` and the selected renderer should have matching
-versions:
+information see the
+[installation docs](https://react-hooks-testing-library.com/installation#renderer). Generally, the
+installed versions for `react` and the selected renderer should have matching versions:
 
 ```sh
 npm install react@^16.9.0
@@ -250,6 +250,9 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/chris110408"><img src="https://avatars.githubusercontent.com/u/10645051?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Chris Chen</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=chris110408" title="Tests">⚠️</a></td>
     <td align="center"><a href="https://www.facebook.com/masoud.bonabi"><img src="https://avatars.githubusercontent.com/u/6429009?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Masious</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=masious" title="Documentation">📖</a></td>
     <td align="center"><a href="https://github.com/Laishuxin"><img src="https://avatars.githubusercontent.com/u/56504759?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Laishuxin</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=Laishuxin" title="Documentation">📖</a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="https://github.com/andersonvom"><img src="https://avatars.githubusercontent.com/u/69922?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Anderson Mesquita</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=andersonvom" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -74,8 +74,8 @@ export type RenderHookOptions<TProps> = {
 }
 
 export type Act = {
-  (callback: () => Promise<void | undefined>): Promise<undefined>
-  (callback: () => void | undefined): void
+  (callback: () => Promise<any>): Promise<undefined>
+  (callback: () => any): void
 }
 
 export type CleanupCallback = () => Promise<void> | void


### PR DESCRIPTION
**What**:

Update `Act` typescript signatures to be more encompassing.

**Why**:

`Promise<void | undefined>` is too restricted for the `callback`
argument taken by `act()` as certain libraries expose hooks that have
async functions that do return values other than `undefined` or `void`.

For example, `react-query` exposes a `fetchNextPage()` async function
that returns a `Promise<SomeLongResult<T, E>>`. The following snippet
illustrates the issue of the current signature of `act()`:

```ts
// after rendering the hook
const hook = renderHook(() => useCustomHook());

// we're forced to write this
await act(() => hook.result.current.fetchNextPage().then(() => {}));

// instead of one of the simpler ways
await act(hook.result.current.fetchNextPage);
await act(() => hook.result.current.fetchNextPage());
```

**How**:

This changes the current signature to accept a function that returns a
`Promise<any>`. It also changes the sync callback signature to `any`
just to keep both signatures consistent and avoid any confusion as to
why the types are different.

**Checklist**:

- [x] Tests
- [x] Ready to be merged
- [x] Added myself to contributors table
