### PR TITLE
feat(server): add SSR test for renderHook

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -145,7 +145,8 @@
       "avatar_url": "https://avatars3.githubusercontent.com/u/3806031?v=4",
       "profile": "https://jsjoe.io",
       "contributions": [
-        "tutorial"
+        "tutorial",
+        "test"
       ]
     },
     {

--- a/README.md
+++ b/README.md
@@ -146,9 +146,9 @@ to test against. It also does not come installed with a specific renderer, we cu
 [`react-test-renderer`](https://www.npmjs.com/package/react-test-renderer) and
 [`react-dom`](https://www.npmjs.com/package/react-dom). You only need to install one of them,
 however, if you do have both installed, we will use `react-test-renderer` as the default. For more
-information see the [installation docs](https://react-hooks-testing-library.com/installation#renderer).
-Generally, the installed versions for `react` and the selected renderer should have matching
-versions:
+information see the
+[installation docs](https://react-hooks-testing-library.com/installation#renderer). Generally, the
+installed versions for `react` and the selected renderer should have matching versions:
 
 ```sh
 npm install react@^16.9.0
@@ -186,7 +186,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/VinceMalone"><img src="https://avatars0.githubusercontent.com/u/2516349?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Vince Malone</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=VinceMalone" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/doppelmutzi"><img src="https://avatars1.githubusercontent.com/u/4130968?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Sebastian Weber</b></sub></a><br /><a href="#blog-doppelmutzi" title="Blogposts">📝</a></td>
     <td align="center"><a href="https://gillchristian.xyz"><img src="https://avatars2.githubusercontent.com/u/8309423?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Christian Gill</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=gillchristian" title="Documentation">📖</a></td>
-    <td align="center"><a href="https://jsjoe.io"><img src="https://avatars3.githubusercontent.com/u/3806031?v=4?s=100" width="100px;" alt=""/><br /><sub><b>JavaScript Joe</b></sub></a><br /><a href="#tutorial-jsjoeio" title="Tutorials">✅</a></td>
+    <td align="center"><a href="https://jsjoe.io"><img src="https://avatars3.githubusercontent.com/u/3806031?v=4?s=100" width="100px;" alt=""/><br /><sub><b>JavaScript Joe</b></sub></a><br /><a href="#tutorial-jsjoeio" title="Tutorials">✅</a> <a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=jsjoeio" title="Tests">⚠️</a></td>
   </tr>
   <tr>
     <td align="center"><a href="http://frontstuff.io"><img src="https://avatars1.githubusercontent.com/u/5370675?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Sarah Dayan</b></sub></a><br /><a href="#platform-sarahdayan" title="Packaging/porting to new platform">📦</a></td>

--- a/src/__tests__/ssr.test.ts
+++ b/src/__tests__/ssr.test.ts
@@ -1,0 +1,18 @@
+/**
+ * @jest-environment node
+ */
+import { useState } from 'react'
+
+// This verifies that renderHook can be called in
+// a SSR-like environment.
+describe('renderHook', () => {
+  function useLoading() {
+    const [loading, setLoading] = useState(false)
+    return { loading, setLoading }
+  }
+  runForRenderers(['server'], ({ renderHook }) => {
+    test('should not throw in SSR environment', () => {
+      expect(() => renderHook(() => useLoading())).not.toThrowError('document is not defined')
+    })
+  })
+})

--- a/src/server/pure.ts
+++ b/src/server/pure.ts
@@ -13,7 +13,7 @@ function createServerRenderer<TProps, TResult>(
 ) {
   let renderProps: TProps | undefined
   let container: HTMLDivElement | undefined
-  let serverOutput: string = ''
+  let serverOutput = ''
   const testHarness = createTestHarness(rendererProps, wrapper, false)
 
   return {

--- a/src/server/pure.ts
+++ b/src/server/pure.ts
@@ -19,13 +19,11 @@ function createServerRenderer<TProps, TResult>(
   return {
     render(props?: TProps) {
       renderProps = props
-      act(() => {
-        try {
-          serverOutput = ReactDOMServer.renderToString(testHarness(props))
-        } catch (e: unknown) {
-          rendererProps.setError(e as Error)
-        }
-      })
+      try {
+        serverOutput = ReactDOMServer.renderToString(testHarness(props))
+      } catch (e: unknown) {
+        rendererProps.setError(e as Error)
+      }
     },
     hydrate() {
       if (container) {


### PR DESCRIPTION
**What**:

This PR adds a new test based on the work done in #607 to fix #605. Partially related to https://github.com/testing-library/react-hooks-testing-library/issues/796

**Why**:

I noticed a test wasn't added when that bug was fixed. I decided to add a test so we could prevent regressions.

**How**:

A new test was added which runs in a Node environment in Jest. 

**Checklist**:

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
