### PR TITLE
React 18 cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@
 [![Tweet](https://img.shields.io/twitter/url/https/github.com/testing-library/react-hooks-testing-library.svg?style=social)](https://twitter.com/intent/tweet?text=Check%20out%20react-hooks-testing-library%20by%20%40testing-library%20https%3A%2F%2Fgithub.com%2Ftesting-library%2Freact-hooks-testing-library%20%F0%9F%91%8D)
 <!-- prettier-ignore-end -->
 
+## A Note about React 18 Support
+
+As part of the changes for React 18, it has been decided that the `renderHook` API provided by this
+library will instead be included as official additions to both `react-testing-library`
+([PR](https://github.com/testing-library/react-testing-library/pull/991)) and
+`react-native-testing-library`
+([PR](https://github.com/callstack/react-native-testing-library/pull/923)) with the intention being
+to provide a more cohesive and consistent implementation for our users.
+
+Please be patient as we finalise these changes in the respective testing libraries.
+
 ## Table of Contents
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
@@ -146,9 +157,9 @@ to test against. It also does not come installed with a specific renderer, we cu
 [`react-test-renderer`](https://www.npmjs.com/package/react-test-renderer) and
 [`react-dom`](https://www.npmjs.com/package/react-dom). You only need to install one of them,
 however, if you do have both installed, we will use `react-test-renderer` as the default. For more
-information see the [installation docs](https://react-hooks-testing-library.com/installation#renderer).
-Generally, the installed versions for `react` and the selected renderer should have matching
-versions:
+information see the
+[installation docs](https://react-hooks-testing-library.com/installation#renderer). Generally, the
+installed versions for `react` and the selected renderer should have matching versions:
 
 ```sh
 npm install react@^16.9.0

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -23,6 +23,17 @@ route: '/'
 
 <hr />
 
+## A Note about React 18 Support
+
+As part of the changes for React 18, it has been decided that the `renderHook` API provided by this
+library will instead be included as official additions to both `react-testing-library`
+([PR](https://github.com/testing-library/react-testing-library/pull/991)) and
+`react-native-testing-library`
+([PR](https://github.com/callstack/react-native-testing-library/pull/923)) with the intention being
+to provide a more cohesive and consistent implementation for our users.
+
+Please be patient as we finalise these changes in the respective testing libraries.
+
 ## The problem
 
 You're writing an awesome custom hook and you want to test it, but as soon as you call it you see

--- a/package.json
+++ b/package.json
@@ -50,17 +50,17 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@types/react": ">=16.9.0",
-    "@types/react-dom": ">=16.9.0",
-    "@types/react-test-renderer": ">=16.9.0",
     "react-error-boundary": "^3.1.0"
   },
   "devDependencies": {
+    "@types/react": "17.0.44",
+    "@types/react-dom": "17.0.15",
+    "@types/react-test-renderer": "17.0.1",
     "@typescript-eslint/eslint-plugin": "5.11.0",
     "@typescript-eslint/parser": "5.11.0",
     "all-contributors-cli": "6.20.0",
     "codecov": "3.8.3",
-    "cross-env": "^7.0.3",
+    "cross-env": "7.0.3",
     "docz": "2.3.1",
     "docz-theme-default": "1.2.0",
     "docz-utils": "2.3.0",
@@ -75,11 +75,15 @@
     "typescript": "4.5.5"
   },
   "peerDependencies": {
-    "react": ">=16.9.0",
-    "react-dom": ">=16.9.0",
-    "react-test-renderer": ">=16.9.0"
+    "@types/react": "^16.9.0 || ^17.0.0",
+    "react": "^16.9.0 || ^17.0.0",
+    "react-dom": "^16.9.0 || ^17.0.0",
+    "react-test-renderer": "^16.9.0 || ^17.0.0"
   },
   "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    },
     "react-dom": {
       "optional": true
     },


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

1. Changing type dependencies to peers deps and restricting  to <18.0
2. Add a note in README and docs about not supporting react 18 in this library
3. ~Update a bunch of dependencies that that have been waiting in other PRs for a while now~
   * Reverted the dependency bumps as it broke both netlify and lint checks

**Why**:

Mostly to stop accidentally resolving type versions that will break things for people and to try to remove any confusion about why we aren't suporting React 18 yet.

**How**:

I've made the type changes a BREAKING CHANGE to be extra cautious for our users in case they need to install the dependencies themselves now, but the update should not require any code changes for anyone.

If all the build check pass for this I will just merge it without waiting for reviews.