### PR TITLE
Fix/better error handling for hydrate

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -603,6 +603,15 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "amovar18",
+      "name": "Kudaligi Amoghavarsha",
+      "avatar_url": "https://avatars.githubusercontent.com/u/59614577?v=4",
+      "profile": "https://github.com/amovar18",
+      "contributions": [
+        "maintenance"
+      ]
     }
   ],
   "skipCi": true,

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ library will instead be included as official additions to both `react-testing-li
 ([PR](https://github.com/callstack/react-native-testing-library/pull/923)) with the intention being
 to provide a more cohesive and consistent implementation for our users.
 
-Please be patient as we finalise these changes in the respective testing libraries.
-In the mean time you can install `@testing-library/react@^13.1`
+Please be patient as we finalise these changes in the respective testing libraries. In the mean time
+you can install `@testing-library/react@^13.1`
 
 ## Table of Contents
 
@@ -262,6 +262,9 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/chris110408"><img src="https://avatars.githubusercontent.com/u/10645051?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Chris Chen</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=chris110408" title="Tests">⚠️</a></td>
     <td align="center"><a href="https://www.facebook.com/masoud.bonabi"><img src="https://avatars.githubusercontent.com/u/6429009?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Masious</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=masious" title="Documentation">📖</a></td>
     <td align="center"><a href="https://github.com/Laishuxin"><img src="https://avatars.githubusercontent.com/u/56504759?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Laishuxin</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=Laishuxin" title="Documentation">📖</a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="https://github.com/amovar18"><img src="https://avatars.githubusercontent.com/u/59614577?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Kudaligi Amoghavarsha</b></sub></a><br /><a href="#maintenance-amovar18" title="Maintenance">🚧</a></td>
   </tr>
 </table>
 

--- a/src/server/pure.ts
+++ b/src/server/pure.ts
@@ -29,11 +29,13 @@ function createServerRenderer<TProps, TResult>(
       if (container) {
         throw new Error('The component can only be hydrated once')
       } else {
-        container = document.createElement('div')
-        container.innerHTML = serverOutput
-        act(() => {
-          ReactDOM.hydrate(testHarness(renderProps), container!)
-        })
+        if (typeof document !== 'undefined') {
+          container = document.createElement('div')
+          container.innerHTML = serverOutput
+          act(() => {
+            ReactDOM.hydrate(testHarness(renderProps), container!)
+          })
+        }
       }
     },
     rerender(props?: TProps) {

--- a/src/server/pure.ts
+++ b/src/server/pure.ts
@@ -35,6 +35,10 @@ function createServerRenderer<TProps, TResult>(
           act(() => {
             ReactDOM.hydrate(testHarness(renderProps), container!)
           })
+        } else {
+          throw new Error(
+            'Hydrate function can only be called in a client environment with a document available.'
+          )
         }
       }
     },


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:
This PR adds a custom error message for `hydrate` function.

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**Why**:
When hydrate function is called in non-browser environment it throws an error `document is not defined` which lead to a non-meaningful error message. This PR now aims to check if document is available or not and then throws a custom error message.
<!-- Why are these changes necessary? -->

**How**:
This PR just provides a wrapper of an `if else` block inside the `hydrate` function and throws a custom error message saying `Hydrate function can only be called in a client environment with a document available.`.
<!-- How were these changes implemented? -->

**Checklist**:

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->
<!-- feel free to add additional comments -->
SideNote: The documentation states that to use `hydrate` function for SSR testing of a hook but the conversation in the issue stated that `render` should be used in non browser environment and `hydrate` should be used on environment where `document` is available. Should the documentation be updated?
