### PR TITLE
Allow newer versions of react-error-boundary

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -603,6 +603,15 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "mycarrysun",
+      "name": "Mike Harrison",
+      "avatar_url": "https://avatars.githubusercontent.com/u/9121901?v=4",
+      "profile": "https://github.com/mycarrysun",
+      "contributions": [
+        "maintenance"
+      ]
     }
   ],
   "skipCi": true,

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ coverage
 
 # settings from IDE
 .vscode
+.idea

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ library will instead be included as official additions to both `react-testing-li
 ([PR](https://github.com/callstack/react-native-testing-library/pull/923)) with the intention being
 to provide a more cohesive and consistent implementation for our users.
 
-Please be patient as we finalise these changes in the respective testing libraries.
-In the mean time you can install `@testing-library/react@^13.1`
+Please be patient as we finalise these changes in the respective testing libraries. In the mean time
+you can install `@testing-library/react@^13.1`
 
 ## Table of Contents
 
@@ -278,6 +278,9 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/chris110408"><img src="https://avatars.githubusercontent.com/u/10645051?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Chris Chen</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=chris110408" title="Tests">⚠️</a></td>
     <td align="center"><a href="https://www.facebook.com/masoud.bonabi"><img src="https://avatars.githubusercontent.com/u/6429009?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Masious</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=masious" title="Documentation">📖</a></td>
     <td align="center"><a href="https://github.com/Laishuxin"><img src="https://avatars.githubusercontent.com/u/56504759?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Laishuxin</b></sub></a><br /><a href="https://github.com/testing-library/react-hooks-testing-library/commits?author=Laishuxin" title="Documentation">📖</a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="https://github.com/mycarrysun"><img src="https://avatars.githubusercontent.com/u/9121901?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Mike Harrison</b></sub></a><br /><a href="#maintenance-mycarrysun" title="Maintenance">🚧</a></td>
   </tr>
 </table>
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "react-error-boundary": "^3.1.0"
+    "react-error-boundary": ">=3.1.0"
   },
   "devDependencies": {
     "@types/react": "17.0.44",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

Allowing the react-error-boundary dependency to be newer than 3.1.0

**Why**:

Its impossible to get correct package resolution without this for users who would like to use 

**How**:

I changed from the dependency being `^3.1.0` to `>=3.1.0`. Then I ran `npm test` to make sure things are working after using `npm upgrade react-error-boundary` to install the new version.

**Checklist**:

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
